### PR TITLE
Avoid go get before build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - "1.10.x"
 
 script:
+  - make get
   - make test
   - make lint
 

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ get:
 	go get -v -t -tags "unit integration" $(TOPLEVEL_DIRS)
 
 .PHONY: test
-test: get
+test:
 	go test -race -tags unit -count 1 $(TOPLEVEL_DIRS)
 
 .PHONY: integration
-integration: get
+integration:
 	go test -race -tags integration -p 1 -count 1 $(TOPLEVEL_DIRS) # p=1 to force Go to run pkg tests serially.
 
 .PHONY: build
-build: get
+build:
 	go build -v -o "$(GOPATH)/bin/$(TSDBCTL_BIN_NAME)" ./cmd/tsdbctl
 
 .PHONY: lint


### PR DESCRIPTION
This causes releases to go get per deliverable, which is undesirable both in terms of build time and consistency across platforms.