### PR TITLE
Unify v3io configuration environment variable. Update tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"os"
 )
 
+const V3ioConfigEnvironmentVariable = "V3IO_CONF"
 const DefaultConfigurationFileName = "v3io.yaml"
 const SCHEMA_CONFIG = ".schema"
 
@@ -123,7 +124,7 @@ type MetricConfig struct {
 
 func LoadConfig(path string) (*V3ioConfig, error) {
 
-	envpath := os.Getenv("V3IO_TSDBCFG_PATH")
+	envpath := os.Getenv(V3ioConfigEnvironmentVariable)
 	if envpath != "" {
 		path = envpath
 	}

--- a/pkg/tsdb/tsdbtest/config.go
+++ b/pkg/tsdb/tsdbtest/config.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 )
 
-const V3ioConfigEnvironmentVariable = "V3IO_CONF"
 const TsdbDefaultTestConfigPath = "testdata"
 const relativeProjectPath = "src/github.com/v3io/v3io-tsdb"
 
@@ -19,7 +18,7 @@ This method will try and load the configuration file from several locations by t
 3. $GOPATH/src/github.com/v3io/v3io-tsdb/v3io.yaml
 */
 func GetV3ioConfigPath() (string, error) {
-	if configurationPath := os.Getenv(V3ioConfigEnvironmentVariable); configurationPath != "" {
+	if configurationPath := os.Getenv(config.V3ioConfigEnvironmentVariable); configurationPath != "" {
 		return configurationPath, nil
 	}
 

--- a/pkg/tsdb/tsdbtest/config_test.go
+++ b/pkg/tsdb/tsdbtest/config_test.go
@@ -32,8 +32,11 @@ func TestGetV3ioConfigPath(t *testing.T) {
 				// Make this test agnostic to environment variables at runtime (store & recover on exit)
 				configPathEnv := os.Getenv(config.V3ioConfigEnvironmentVariable)
 				os.Unsetenv(config.V3ioConfigEnvironmentVariable)
+
 				if _, err := os.Stat(filepath.Join(TsdbDefaultTestConfigPath, config.DefaultConfigurationFileName)); !os.IsNotExist(err) {
-					return func() {}
+					return func() {
+						os.Setenv(config.V3ioConfigEnvironmentVariable, configPathEnv)
+					}
 				} else {
 					path := TsdbDefaultTestConfigPath
 					if err := os.Mkdir(path, 0777); err != nil {
@@ -53,8 +56,11 @@ func TestGetV3ioConfigPath(t *testing.T) {
 				// Make this test agnostic to environment variables at runtime (store & recover on exit)
 				configPathEnv := os.Getenv(config.V3ioConfigEnvironmentVariable)
 				os.Unsetenv(config.V3ioConfigEnvironmentVariable)
+
 				if _, err := os.Stat(filepath.Join(projectHome, config.DefaultConfigurationFileName)); !os.IsNotExist(err) {
-					return func() {}
+					return func() {
+						os.Setenv(config.V3ioConfigEnvironmentVariable, configPathEnv)
+					}
 				} else {
 					path := projectHome
 					createTestConfig(t, path)
@@ -66,12 +72,16 @@ func TestGetV3ioConfigPath(t *testing.T) {
 			}},
 
 		{description: "get config from env var",
-			expectedPath: config.DefaultConfigurationFileName,
+			expectedPath: getConfigPathFromEnvOrDefault(),
 			setup: func() func() {
-				os.Setenv(config.V3ioConfigEnvironmentVariable, config.DefaultConfigurationFileName)
-				return func() {
-					os.Unsetenv(config.V3ioConfigEnvironmentVariable)
+				env := os.Getenv(config.V3ioConfigEnvironmentVariable)
+				if env == "" {
+					os.Setenv(config.V3ioConfigEnvironmentVariable, config.DefaultConfigurationFileName)
+					return func() {
+						os.Unsetenv(config.V3ioConfigEnvironmentVariable)
+					}
 				}
+				return func() {}
 			}},
 	}
 
@@ -80,6 +90,14 @@ func TestGetV3ioConfigPath(t *testing.T) {
 			testGetV3ioConfigPathCase(t, test.expectedPath, test.setup)
 		})
 	}
+}
+
+func getConfigPathFromEnvOrDefault() string {
+	configPath := os.Getenv(config.V3ioConfigEnvironmentVariable)
+	if configPath == "" {
+		configPath = config.DefaultConfigurationFileName
+	}
+	return configPath
 }
 
 func testGetV3ioConfigPathCase(t *testing.T, expected string, setup func() func()) {

--- a/pkg/tsdb/tsdbtest/config_test.go
+++ b/pkg/tsdb/tsdbtest/config_test.go
@@ -29,6 +29,9 @@ func TestGetV3ioConfigPath(t *testing.T) {
 		{description: "get config from package testdata",
 			expectedPath: filepath.Join(TsdbDefaultTestConfigPath, config.DefaultConfigurationFileName),
 			setup: func() func() {
+				// Make this test agnostic to environment variables at runtime (store & recover on exit)
+				configPathEnv := os.Getenv(config.V3ioConfigEnvironmentVariable)
+				os.Unsetenv(config.V3ioConfigEnvironmentVariable)
 				if _, err := os.Stat(filepath.Join(TsdbDefaultTestConfigPath, config.DefaultConfigurationFileName)); !os.IsNotExist(err) {
 					return func() {}
 				} else {
@@ -38,6 +41,7 @@ func TestGetV3ioConfigPath(t *testing.T) {
 					}
 					createTestConfig(t, path)
 					return func() {
+						os.Setenv(config.V3ioConfigEnvironmentVariable, configPathEnv)
 						os.RemoveAll(path)
 					}
 				}
@@ -46,12 +50,16 @@ func TestGetV3ioConfigPath(t *testing.T) {
 		{description: "get config from project root",
 			expectedPath: filepath.Join(projectHome, config.DefaultConfigurationFileName),
 			setup: func() func() {
+				// Make this test agnostic to environment variables at runtime (store & recover on exit)
+				configPathEnv := os.Getenv(config.V3ioConfigEnvironmentVariable)
+				os.Unsetenv(config.V3ioConfigEnvironmentVariable)
 				if _, err := os.Stat(filepath.Join(projectHome, config.DefaultConfigurationFileName)); !os.IsNotExist(err) {
 					return func() {}
 				} else {
 					path := projectHome
 					createTestConfig(t, path)
 					return func() {
+						os.Setenv(config.V3ioConfigEnvironmentVariable, configPathEnv)
 						os.Remove(path)
 					}
 				}
@@ -60,9 +68,9 @@ func TestGetV3ioConfigPath(t *testing.T) {
 		{description: "get config from env var",
 			expectedPath: config.DefaultConfigurationFileName,
 			setup: func() func() {
-				os.Setenv(V3ioConfigEnvironmentVariable, config.DefaultConfigurationFileName)
+				os.Setenv(config.V3ioConfigEnvironmentVariable, config.DefaultConfigurationFileName)
 				return func() {
-					os.Unsetenv(V3ioConfigEnvironmentVariable)
+					os.Unsetenv(config.V3ioConfigEnvironmentVariable)
 				}
 			}},
 	}

--- a/pkg/tsdb/tsdbtest/tsdbtest.go
+++ b/pkg/tsdb/tsdbtest/tsdbtest.go
@@ -1,6 +1,7 @@
 package tsdbtest
 
 import (
+	json2 "encoding/json"
 	"fmt"
 	"github.com/v3io/v3io-tsdb/pkg/config"
 	. "github.com/v3io/v3io-tsdb/pkg/tsdb"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	json2 "encoding/json"
 )
 
 type DataPoint struct {

--- a/pkg/tsdb/tsdbtest/tsdbtest.go
+++ b/pkg/tsdb/tsdbtest/tsdbtest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	json2 "encoding/json"
 )
 
 type DataPoint struct {
@@ -44,7 +45,8 @@ func DeleteTSDB(t testing.TB, v3ioConfig *config.V3ioConfig) {
 func CreateTestTSDB(t testing.TB, v3ioConfig *config.V3ioConfig) {
 	schema := testutils.CreateSchema(t, "*")
 	if err := CreateTSDB(v3ioConfig, &schema); err != nil {
-		t.Fatalf("Failed to create TSDB. reason: %s", err)
+		v3ioConfigAsJson, _ := json2.MarshalIndent(v3ioConfig, "", "  ")
+		t.Fatalf("Failed to create TSDB. Reason: %s\nConfiguration:\n%s", err, string(v3ioConfigAsJson))
 	}
 }
 
@@ -69,7 +71,8 @@ func SetUpWithData(t *testing.T, v3ioConfig *config.V3ioConfig, metricName strin
 func SetUpWithDBConfig(t *testing.T, v3ioConfig *config.V3ioConfig, schema *config.Schema) func() {
 	v3ioConfig.Path = fmt.Sprintf("%s-%d", t.Name(), time.Now().Nanosecond())
 	if err := CreateTSDB(v3ioConfig, schema); err != nil {
-		t.Fatalf("Failed to create TSDB. reason: %s", err)
+		v3ioConfigAsJson, _ := json2.MarshalIndent(v3ioConfig, "", "  ")
+		t.Fatalf("Failed to create TSDB. Reason: %s\nConfiguration:\n%s", err, string(v3ioConfigAsJson))
 	}
 
 	return func() {

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+	"encoding/json"
 )
 
 func TestIngestData(t *testing.T) {
@@ -137,8 +138,8 @@ func TestQueryData(t *testing.T) {
 	}{
 		{desc: "Should ingest and query one data point", metricName: "cpu",
 			labels: utils.FromStrings("testLabel", "balbala"),
-			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
-			from:   0, to: 1532940510 + 1,
+			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+			from: 0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
 		{desc: "Should ingest and query multiple data points", metricName: "cpu",
@@ -153,22 +154,22 @@ func TestQueryData(t *testing.T) {
 
 		{desc: "Should query with filter on metric name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
 			filter: "_name=='cpu'",
-			from:   0, to: 1532940510 + 1,
+			from: 0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 33.3}}}},
 
 		{desc: "Should query with filter on label name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
+			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
 			filter: "os=='linux'",
-			from:   0, to: 1532940510 + 1,
+			from: 0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 31.3}}}},
 
 		{desc: "Should ingest and query data with '-' in the metric name (IG-8585)", metricName: "cool-cpu",
 			labels: utils.FromStrings("testLabel", "balbala"),
-			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
-			from:   0, to: 1532940510 + 1,
+			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+			from: 0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
 		{desc: "Should ingest and query by time", metricName: "cpu",
@@ -195,7 +196,7 @@ func TestQueryData(t *testing.T) {
 				{Time: 1532940510 + 10, Value: 100.4}},
 			from: 1532940510, to: 1532940510 + 11,
 			aggregators: "sum",
-			expected:    map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}}}},
+			expected: map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}}}},
 
 		{desc: "Should ingest and query multiple aggregators", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
@@ -217,9 +218,9 @@ func TestQueryData(t *testing.T) {
 
 		{desc: "Should query with filter on not existing metric name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
 			filter: "_name=='hahaha'",
-			from:   0, to: 1532940510 + 1,
+			from: 0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{}},
 	}
 
@@ -299,13 +300,13 @@ func TestQueryDataOverlappingWindow(t *testing.T) {
 	}{
 		{desc: "Should ingest and query with windowing",
 			metricName: "cpu",
-			labels:     utils.FromStrings("os", "linux", "iguaz", "yesplease"),
+			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
 			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
 				{Time: 1532944110, Value: 314.3},
 				{Time: 1532947710, Value: 300.3},
 				{Time: 1532951310, Value: 3234.6}},
 			from: 0, to: 1532954910,
-			windows:     []int{1, 2, 4},
+			windows: []int{1, 2, 4},
 			aggregators: "sum",
 			expected: map[string][]tsdbtest.DataPoint{
 				"sum": {{Time: 1532937600, Value: 4163.5},
@@ -315,13 +316,13 @@ func TestQueryDataOverlappingWindow(t *testing.T) {
 
 		{desc: "Should ingest and query with windowing on multiple agg",
 			metricName: "cpu",
-			labels:     utils.FromStrings("os", "linux", "iguaz", "yesplease"),
+			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
 			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
 				{Time: 1532944110, Value: 314.3},
 				{Time: 1532947710, Value: 300.3},
 				{Time: 1532951310, Value: 3234.6}},
 			from: 0, to: 1532954910,
-			windows:     []int{1, 2, 4},
+			windows: []int{1, 2, 4},
 			aggregators: "sum,count,sqr",
 			expected: map[string][]tsdbtest.DataPoint{
 				"sum": {{Time: 1532937600, Value: 4163.5},
@@ -446,7 +447,8 @@ func TestDeleteTSDB(t *testing.T) {
 	schema := testutils.CreateSchema(t, "count,sum")
 	v3ioConfig.Path = t.Name()
 	if err := CreateTSDB(v3ioConfig, &schema); err != nil {
-		t.Fatalf("Failed to create TSDB. reason: %s", err)
+		v3ioConfigAsJson, _ := json.MarshalIndent(v3ioConfig, "", "  ")
+		t.Fatalf("Failed to create TSDB. Reason: %s\nConfiguration:\n%s", err, string(v3ioConfigAsJson))
 	}
 
 	adapter, err := NewV3ioAdapter(v3ioConfig, nil, nil)

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -23,6 +23,7 @@ such restriction.
 package tsdb_test
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/v3io/v3io-go-http"
 	"github.com/v3io/v3io-tsdb/pkg/chunkenc"
@@ -34,7 +35,6 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
-	"encoding/json"
 )
 
 func TestIngestData(t *testing.T) {
@@ -138,8 +138,8 @@ func TestQueryData(t *testing.T) {
 	}{
 		{desc: "Should ingest and query one data point", metricName: "cpu",
 			labels: utils.FromStrings("testLabel", "balbala"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
-			from: 0, to: 1532940510 + 1,
+			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+			from:   0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
 		{desc: "Should ingest and query multiple data points", metricName: "cpu",
@@ -154,22 +154,22 @@ func TestQueryData(t *testing.T) {
 
 		{desc: "Should query with filter on metric name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
 			filter: "_name=='cpu'",
-			from: 0, to: 1532940510 + 1,
+			from:   0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 33.3}}}},
 
 		{desc: "Should query with filter on label name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
+			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
 			filter: "os=='linux'",
-			from: 0, to: 1532940510 + 1,
+			from:   0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 31.3}}}},
 
 		{desc: "Should ingest and query data with '-' in the metric name (IG-8585)", metricName: "cool-cpu",
 			labels: utils.FromStrings("testLabel", "balbala"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
-			from: 0, to: 1532940510 + 1,
+			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+			from:   0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
 		{desc: "Should ingest and query by time", metricName: "cpu",
@@ -196,7 +196,7 @@ func TestQueryData(t *testing.T) {
 				{Time: 1532940510 + 10, Value: 100.4}},
 			from: 1532940510, to: 1532940510 + 11,
 			aggregators: "sum",
-			expected: map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}}}},
+			expected:    map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940000, Value: 701.0}}}},
 
 		{desc: "Should ingest and query multiple aggregators", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
@@ -218,9 +218,9 @@ func TestQueryData(t *testing.T) {
 
 		{desc: "Should query with filter on not existing metric name", metricName: "cpu",
 			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+			data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
 			filter: "_name=='hahaha'",
-			from: 0, to: 1532940510 + 1,
+			from:   0, to: 1532940510 + 1,
 			expected: map[string][]tsdbtest.DataPoint{}},
 	}
 
@@ -300,13 +300,13 @@ func TestQueryDataOverlappingWindow(t *testing.T) {
 	}{
 		{desc: "Should ingest and query with windowing",
 			metricName: "cpu",
-			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
+			labels:     utils.FromStrings("os", "linux", "iguaz", "yesplease"),
 			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
 				{Time: 1532944110, Value: 314.3},
 				{Time: 1532947710, Value: 300.3},
 				{Time: 1532951310, Value: 3234.6}},
 			from: 0, to: 1532954910,
-			windows: []int{1, 2, 4},
+			windows:     []int{1, 2, 4},
 			aggregators: "sum",
 			expected: map[string][]tsdbtest.DataPoint{
 				"sum": {{Time: 1532937600, Value: 4163.5},
@@ -316,13 +316,13 @@ func TestQueryDataOverlappingWindow(t *testing.T) {
 
 		{desc: "Should ingest and query with windowing on multiple agg",
 			metricName: "cpu",
-			labels: utils.FromStrings("os", "linux", "iguaz", "yesplease"),
+			labels:     utils.FromStrings("os", "linux", "iguaz", "yesplease"),
 			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
 				{Time: 1532944110, Value: 314.3},
 				{Time: 1532947710, Value: 300.3},
 				{Time: 1532951310, Value: 3234.6}},
 			from: 0, to: 1532954910,
-			windows: []int{1, 2, 4},
+			windows:     []int{1, 2, 4},
 			aggregators: "sum,count,sqr",
 			expected: map[string][]tsdbtest.DataPoint{
 				"sum": {{Time: 1532937600, Value: 4163.5},

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -87,7 +87,7 @@ AppendOneByOne: true
 ### Define following environment variables.
 > Note: you can also define variables locally in a script
 ```bash 
-    V3IO_TSDBCFG_PATH="$HOME/go/bin/v3io-custom.yaml"
+    V3IO_CONF="$HOME/go/bin/v3io-custom.yaml"
     TSDB_BENCH_INGEST_CONFIG="$HOME/go/bin/tsdb-bench-test-config.yaml"
 ```
 ### Run ingestion benchmark test for desired time interval to populate the TSDB.
@@ -111,7 +111,7 @@ Use the following script as a reference:
     cd $HOME/go/src/github.com/v3io/v3io-tsdb/cmd/tsdbctl
     
     # Note, you can select either "-bench=^BenchmarkIngest$" or "-bench=^BenchmarkIngestWithNuclio$" test
-    time V3IO_TSDBCFG_PATH="$HOME/go/bin/v3io-custom.yaml" TSDB_BENCH_INGEST_CONFIG="$HOME/go/bin/tsdb-bench-test-config.yaml" go test -benchtime $BENCH_TIME -run=DO_NOT_RUN_TESTS -bench=^BenchmarkIngest$ ../../test/benchmark
+    time V3IO_CONF="$HOME/go/bin/v3io-custom.yaml" TSDB_BENCH_INGEST_CONFIG="$HOME/go/bin/tsdb-bench-test-config.yaml" go test -benchtime $BENCH_TIME -run=DO_NOT_RUN_TESTS -bench=^BenchmarkIngest$ ../../test/benchmark
     
     echo Done
 ```
@@ -127,14 +127,14 @@ Use the following script as a reference:
     GOBIN=$HOME/go/bin
     LOOK_BACK_INTERVAL=72h
     TSDB_ROLLUP_INTERVAL=5m
-    V3IO_CONFIG_PATH=$GOBIN/v3io-custom.yaml
+    V3IO_CONF=$GOBIN/v3io-custom.yaml
     
     for x in {A..Z}
     do
       for ((i = 0; i < 10; i++))
       do
         echo Querying Name_${x}_${i} ...
-        $GOBIN/tsdbctl query Name_${x}_${i} -a count -l $LOOK_BACK_INTERVAL -i $TSDB_ROLLUP_INTERVAL  -c $V3IO_CONFIG_PATH
+        $GOBIN/tsdbctl query Name_${x}_${i} -a count -l $LOOK_BACK_INTERVAL -i $TSDB_ROLLUP_INTERVAL  -c $V3IO_CONF
       done
     done
     


### PR DESCRIPTION
* Unify environment variable name
* Make test agnostic to runtime environment
* Print configuration in case of test failure

Example command for running tests:
`V3IO_CONF=<real-path>/v3io.yaml go test -tags "integration unit" ../../...`

Important Note: After merging this PR only `V3IO_CONF` will be respected