### PR TITLE
Fix label values

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -168,7 +168,7 @@ func (q *V3ioQuerier) Close() error {
 
 func (q *V3ioQuerier) getMetricNames() ([]string, error) {
 	input := v3io.GetItemsInput{
-		Path: q.cfg.Path + "/names/",
+		Path:           q.cfg.Path + "/names/",
 		AttributeNames: []string{"__name"},
 	}
 
@@ -207,7 +207,7 @@ func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
 
 	// get all labelsets
 	input := v3io.GetItemsInput{
-		Path: q.partitionMngr.GetPartitionsPaths()[0],
+		Path:           q.partitionMngr.GetPartitionsPaths()[0],
 		AttributeNames: []string{"_lset"},
 	}
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -198,8 +198,10 @@ func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
 		return nil, err
 	}
 
+	partitionPaths := q.partitionMngr.GetPartitionsPaths()
+
 	// if no partitions yet - there are no labels
-	if len(q.partitionMngr.GetPartitionsPaths()) == 0 {
+	if len(partitionPaths) == 0 {
 		return nil, nil
 	}
 
@@ -207,7 +209,7 @@ func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
 
 	// get all labelsets
 	input := v3io.GetItemsInput{
-		Path:           q.partitionMngr.GetPartitionsPaths()[0],
+		Path:           partitionPaths[0],
 		AttributeNames: []string{"_lset"},
 	}
 
@@ -238,10 +240,10 @@ func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
 	}
 
 	if iter.Err() != nil {
-		q.logger.InfoWith("Failed to read names, assume empty list", "err", iter.Err().Error())
+		q.logger.InfoWith("Failed to read label values, assume empty list", "err", iter.Err().Error())
 	}
 
-	labelValues := []string{}
+	var labelValues []string
 	for labelValue, _ := range labelValuesMap {
 		labelValues = append(labelValues, labelValue)
 	}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -240,7 +240,7 @@ func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
 	}
 
 	if iter.Err() != nil {
-		q.logger.InfoWith("Failed to read label values, assume empty list", "err", iter.Err().Error())
+		q.logger.InfoWith("Failed to read label values, returning empty list", "err", iter.Err().Error())
 	}
 
 	var labelValues []string

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -154,27 +154,97 @@ func (q *V3ioQuerier) queryNumericPartition(
 }
 
 // return the current metric names
-func (q *V3ioQuerier) LabelValues(name string) ([]string, error) {
+func (q *V3ioQuerier) LabelValues(labelKey string) ([]string, error) {
+	if labelKey == "__name__" {
+		return q.getMetricNames()
+	} else {
+		return q.getLabelValues(labelKey)
+	}
+}
 
-	list := []string{}
-	input := v3io.GetItemsInput{Path: q.cfg.Path + "/names/", AttributeNames: []string{"__name"}, Filter: ""}
-	iter, err := utils.NewAsyncItemsCursor(q.container, &input, q.cfg.QryWorkers, []string{}, q.logger)
-	q.logger.DebugWith("GetItems to read names", "input", input, "err", err)
-	if err != nil {
-		return list, err
+func (q *V3ioQuerier) Close() error {
+	return nil
+}
+
+func (q *V3ioQuerier) getMetricNames() ([]string, error) {
+	input := v3io.GetItemsInput{
+		Path: q.cfg.Path + "/names/",
+		AttributeNames: []string{"__name"},
 	}
 
+	iter, err := utils.NewAsyncItemsCursor(q.container, &input, q.cfg.QryWorkers, []string{}, q.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	var metricNames []string
+
 	for iter.Next() {
-		name := iter.GetField("__name").(string)
-		list = append(list, name)
+		metricNames = append(metricNames, iter.GetField("__name").(string))
+	}
+
+	if iter.Err() != nil {
+		q.logger.InfoWith("Failed to read metric names, returning empty list", "err", iter.Err().Error())
+	}
+
+	return metricNames, nil
+}
+
+func (q *V3ioQuerier) getLabelValues(labelKey string) ([]string, error) {
+
+	// sync partition manager (hack)
+	err := q.partitionMngr.ReadAndUpdateSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	// if no partitions yet - there are no labels
+	if len(q.partitionMngr.GetPartitionsPaths()) == 0 {
+		return nil, nil
+	}
+
+	labelValuesMap := map[string]struct{}{}
+
+	// get all labelsets
+	input := v3io.GetItemsInput{
+		Path: q.partitionMngr.GetPartitionsPaths()[0],
+		AttributeNames: []string{"_lset"},
+	}
+
+	iter, err := utils.NewAsyncItemsCursor(q.container, &input, q.cfg.QryWorkers, []string{}, q.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// iterate over the results
+	for iter.Next() {
+		labelSet := iter.GetField("_lset").(string)
+
+		// the labelSet will be k1=v1,k2=v2, k2=v3. Assuming labelKey is "k2", we want to convert
+		// that to [v2, v3]
+
+		// split at "," to get k=v pairs
+		for _, label := range strings.Split(labelSet, ",") {
+
+			// split at "=" to get label key and label value
+			splitLabel := strings.SplitN(label, "=", 2)
+
+			// if we got two elements and the first element (the key) is equal to what we're looking
+			// for, save the label value in the map. use a map to prevent duplications
+			if len(splitLabel) == 2 && splitLabel[0] == labelKey {
+				labelValuesMap[splitLabel[1]] = struct{}{}
+			}
+		}
 	}
 
 	if iter.Err() != nil {
 		q.logger.InfoWith("Failed to read names, assume empty list", "err", iter.Err().Error())
 	}
-	return list, nil
-}
 
-func (q *V3ioQuerier) Close() error {
-	return nil
+	labelValues := []string{}
+	for labelValue, _ := range labelValuesMap {
+		labelValues = append(labelValues, labelValue)
+	}
+
+	return labelValues, nil
 }

--- a/pkg/tsdbctl/info.go
+++ b/pkg/tsdbctl/info.go
@@ -84,7 +84,7 @@ func (ic *infoCommandeer) info() error {
 		}
 
 		// get all metric names
-		names, err := qry.LabelValues("")
+		names, err := qry.LabelValues("__name__")
 		if err != nil {
 			return errors.Wrap(err, "Failed to get labels")
 		}


### PR DESCRIPTION
`LabelValues` should be able to return the values of a given label. Before this PR, `LabelValues` only supporting getting the `__name__` label, effectively returning metric names. This PR introduces support for returning values of other labels. It does so by getting all the `_lset`s in the first partition, parsing them and looking for the given label.

While this implementation is limited (as it only gets the label values of the label in the first partition), it is good enough for netops and other cases where all metrics are created at once. 