### PR TITLE
Align TSDB CLI with @sharonl recommendations

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ import (
 const (
 	V3ioConfigEnvironmentVariable = "V3IO_CONF"
 	DefaultConfigurationFileName  = "v3io.yaml"
-	SchemaConfigFileName                 = ".schema"
+	SchemaConfigFileName          = ".schema"
 
 	defaultNumberOfIngestWorkers = 1
 	defaultNumberOfQueryWorkers  = 8

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,7 +198,7 @@ func loadConfig(path string) (*V3ioConfig, error) {
 			return nil, errors.Wrap(err, "failed to read configuration")
 		}
 	} else {
-		data, err := ioutil.ReadFile(resolvedPath)
+		data, err = ioutil.ReadFile(resolvedPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/partmgr/partmgr.go
+++ b/pkg/partmgr/partmgr.go
@@ -191,7 +191,7 @@ func (p *PartitionManager) updateSchema() (err error) {
 			return
 		}
 		if p.container != nil { //tests use case only
-			err = p.container.Sync.PutObject(&v3io.PutObjectInput{Path: path.Join(p.Path(), config.SCHEMA_CONFIG), Body: data})
+			err = p.container.Sync.PutObject(&v3io.PutObjectInput{Path: path.Join(p.Path(), config.SchemaConfigFileName), Body: data})
 		}
 	})
 
@@ -235,7 +235,7 @@ func (p *PartitionManager) ReadAndUpdateSchema() (err error) {
 	}
 
 	timer.Time(func() {
-		fullPath := path.Join(p.Path(), config.SCHEMA_CONFIG)
+		fullPath := path.Join(p.Path(), config.SchemaConfigFileName)
 		resp, err := p.container.Sync.GetObject(&v3io.GetObjectInput{Path: fullPath})
 		if err != nil {
 			err = errors.Wrap(err, "Failed to read schema at path: "+fullPath)

--- a/pkg/tsdb/v3iotsdb.go
+++ b/pkg/tsdb/v3iotsdb.go
@@ -59,7 +59,7 @@ func CreateTSDB(v3iocfg *config.V3ioConfig, schema *config.Schema) error {
 		return errors.Wrap(err, "Failed to Marshal schema file")
 	}
 
-	path := pathUtil.Join(v3iocfg.Path, config.SCHEMA_CONFIG)
+	path := pathUtil.Join(v3iocfg.Path, config.SchemaConfigFileName)
 	// check if the config file already exist, abort if it does
 	_, err = container.Sync.GetObject(&v3io.GetObjectInput{Path: path})
 	if err == nil {
@@ -119,7 +119,7 @@ func (a *V3ioAdapter) GetContainer() (*v3io.Container, string) {
 func (a *V3ioAdapter) connect() error {
 
 	fullpath := pathUtil.Join(a.cfg.V3ioUrl, a.cfg.Container, a.cfg.Path)
-	resp, err := a.container.Sync.GetObject(&v3io.GetObjectInput{Path: pathUtil.Join(a.cfg.Path, config.SCHEMA_CONFIG)})
+	resp, err := a.container.Sync.GetObject(&v3io.GetObjectInput{Path: pathUtil.Join(a.cfg.Path, config.SchemaConfigFileName)})
 	if err != nil {
 		return errors.Wrap(err, "Failed to read schema at path: "+fullpath)
 	}
@@ -212,7 +212,7 @@ func (a *V3ioAdapter) DeleteDB(configExists bool, force bool, fromTime int64, to
 		}
 	}
 	if configExists {
-		schemaPath := pathUtil.Join(a.cfg.Path, config.SCHEMA_CONFIG)
+		schemaPath := pathUtil.Join(a.cfg.Path, config.SchemaConfigFileName)
 		a.logger.Info("Delete TSDB config in path %s", schemaPath)
 		err := a.container.Sync.DeleteObject(&v3io.DeleteObjectInput{Path: schemaPath})
 		if err != nil && !force {

--- a/pkg/tsdbctl/add.go
+++ b/pkg/tsdbctl/add.go
@@ -56,7 +56,7 @@ func newAddCommandeer(rootCommandeer *RootCommandeer) *addCommandeer {
 
 	cmd := &cobra.Command{
 		Use:     "add <metric> [labels] [flags]",
-		Aliases: []string{"append"},
+		Aliases: []string{"append", "ingest"},
 		Short:   "add samples to metric. e.g. add http_req method=get -d 99.9",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -86,7 +86,9 @@ func newAddCommandeer(rootCommandeer *RootCommandeer) *addCommandeer {
 	cmd.Flags().StringVarP(&commandeer.vArr, "values", "d", "", "values array, comma separated")
 	cmd.Flags().StringVarP(&commandeer.inFile, "file", "f", "", "CSV input file")
 	cmd.Flags().BoolVar(&commandeer.stdin, "stdin", false, "read from standard input")
+	cmd.Flags().Lookup("stdin").Hidden = true
 	cmd.Flags().IntVar(&commandeer.delay, "delay", 0, "Add delay per insert batch in milisec")
+	cmd.Flags().Lookup("delay").Hidden = true
 
 	commandeer.cmd = cmd
 

--- a/pkg/tsdbctl/create.go
+++ b/pkg/tsdbctl/create.go
@@ -70,12 +70,12 @@ func newCreateCommandeer(rootCommandeer *RootCommandeer) *createCommandeer {
 		},
 	}
 
-	cmd.Flags().StringVarP(&commandeer.defaultRollups, "rollups", "r", "",
+	cmd.Flags().StringVarP(&commandeer.defaultRollups, "aggregates", "a", "",
 		"Default aggregation rollups, comma seperated: count,avg,sum,min,max,stddev")
-	cmd.Flags().StringVarP(&commandeer.rollupInterval, "rollup-interval", "i", defaultRollupInterval, "aggregation interval")
+	cmd.Flags().StringVarP(&commandeer.rollupInterval, "aggregation-granularity", "i", defaultRollupInterval, "aggregation interval")
 	cmd.Flags().IntVarP(&commandeer.shardingBuckets, "sharding-buckets", "b", defaultShardingBuckets, "number of buckets to split key")
 	// TODO: enable sample-retention when supported
-	// cmd.Flags().IntVarP(&commandeer.sampleRetention, "sample-retention", "a", defaultSampleRetentionHours, "sample retention in hours")
+	// cmd.Flags().IntVarP(&commandeer.sampleRetention, "sample-retention", "r", defaultSampleRetentionHours, "sample retention in hours")
 	cmd.Flags().StringVar(&commandeer.sampleRate, "rate", defaultIngestionRate, "sample rate")
 
 	commandeer.cmd = cmd

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -21,17 +21,21 @@ such restriction.
 package tsdbctl
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/v3io/v3io-tsdb/pkg/utils"
+	"os"
+	"strings"
 	"time"
 )
 
 type delCommandeer struct {
 	cmd            *cobra.Command
 	rootCommandeer *RootCommandeer
-	delConfig      bool
+	deleteAll      bool
+	ignoreErrors   bool
 	force          bool
 	fromTime       string
 	toTime         string
@@ -53,10 +57,11 @@ func newDeleteCommandeer(rootCommandeer *RootCommandeer) *delCommandeer {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&commandeer.delConfig, "del-config", "d", false, "Delete the TSDB config as well")
-	cmd.Flags().BoolVarP(&commandeer.force, "force", "f", false, "Delete all elements even if some steps fail")
-	cmd.Flags().StringVarP(&commandeer.toTime, "end", "e", "now", "to time")
-	cmd.Flags().StringVarP(&commandeer.fromTime, "begin", "b", "0", "from time")
+	cmd.Flags().BoolVarP(&commandeer.deleteAll, "all", "a", false, "Delete the TSDB table (including all content and the configuration schema file)")
+	cmd.Flags().BoolVarP(&commandeer.ignoreErrors, "ignore-errors", "i", false, "Delete all elements even if some steps fail")
+	cmd.Flags().BoolVarP(&commandeer.force, "force", "f", false, "Delete without prompt")
+	cmd.Flags().StringVarP(&commandeer.toTime, "end", "e", "now", "TO time")
+	cmd.Flags().StringVarP(&commandeer.fromTime, "begin", "b", "0", "FROM time")
 	commandeer.cmd = cmd
 
 	return commandeer
@@ -87,11 +92,45 @@ func (ic *delCommandeer) delete() error {
 			return err
 		}
 	}
-	err = ic.rootCommandeer.adapter.DeleteDB(ic.delConfig, ic.force, from, to)
-	if err != nil {
-		return errors.Wrap(err, "Failed to delete DB")
+
+	if !ic.force {
+		confirmedByUser, err := getConfirmation(
+			fmt.Sprintf("You are about to delete the '%s' table. Are you sure?", ic.rootCommandeer.v3iocfg.Path))
+		if err != nil {
+			return err
+		}
+
+		if !confirmedByUser {
+			return errors.New("Cancelled by user")
+		}
 	}
-	fmt.Printf("Deleted table %s succsesfuly\n", ic.rootCommandeer.v3iocfg.Path)
+
+	err = ic.rootCommandeer.adapter.DeleteDB(ic.deleteAll, ic.ignoreErrors, from, to)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to delete table '%s'", ic.rootCommandeer.v3iocfg.Path)
+	}
+	fmt.Printf("Table '%s' has been deleted\n", ic.rootCommandeer.v3iocfg.Path)
 
 	return nil
+}
+
+func getConfirmation(prompt string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf("%s [y/n]: ", prompt)
+
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			errors.Wrap(err, "failed to get user input")
+		}
+
+		response = strings.ToLower(strings.TrimSpace(response))
+
+		if response == "y" || response == "yes" {
+			return true, nil
+		} else if response == "n" || response == "no" {
+			return false, nil
+		}
+	}
 }

--- a/pkg/tsdbctl/query.go
+++ b/pkg/tsdbctl/query.go
@@ -72,9 +72,9 @@ func newQueryCommandeer(rootCommandeer *RootCommandeer) *queryCommandeer {
 	cmd.Flags().StringVarP(&commandeer.filter, "filter", "f", "", "v3io query filter e.g. method=='get'")
 	cmd.Flags().StringVarP(&commandeer.last, "last", "l", "", "last min/hours/days e.g. 15m")
 	cmd.Flags().StringVarP(&commandeer.windows, "windows", "w", "", "comma separated list of overlapping windows")
-	cmd.Flags().StringVarP(&commandeer.functions, "aggregators", "a", "",
+	cmd.Flags().StringVarP(&commandeer.functions, "aggregates", "a", "",
 		"comma separated list of aggregation functions, e.g. count,avg,sum,min,max,stddev,stdvar,last,rate")
-	cmd.Flags().StringVarP(&commandeer.step, "step", "i", "", "interval step for aggregation functions")
+	cmd.Flags().StringVarP(&commandeer.step, "aggregation-interval", "i", "", "interval step for aggregation functions")
 
 	commandeer.cmd = cmd
 

--- a/pkg/tsdbctl/time.go
+++ b/pkg/tsdbctl/time.go
@@ -65,6 +65,7 @@ func newTimeCommandeer(rootCommandeer *RootCommandeer) *timeCommandeer {
 
 		},
 	}
+	cmd.Hidden = true
 
 	commandeer.cmd = cmd
 

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -48,6 +48,8 @@ type RootCommandeer struct {
 	cfgFilePath string
 	verbose     string
 	container   string
+	username    string
+	password    string
 	Reporter    *performance.MetricReporter
 }
 
@@ -65,9 +67,11 @@ func NewRootCommandeer() *RootCommandeer {
 	cmd.PersistentFlags().StringVarP(&commandeer.verbose, "verbose", "v", "", "Verbose output")
 	cmd.PersistentFlags().Lookup("verbose").NoOptDefVal = "debug"
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "dbpath", "p", "", "sub path for the TSDB, inside the container")
-	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - username:password@ip:port/container")
-	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "c", "", "path to yaml config file")
-	cmd.PersistentFlags().StringVarP(&commandeer.container, "container", "u", "", "container to use")
+	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - username:password@ip:port")
+	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "g", "", "path to yaml config file")
+	cmd.PersistentFlags().StringVarP(&commandeer.container, "container", "c", "", "container to use")
+	cmd.PersistentFlags().StringVarP(&commandeer.username, "username", "u", "", "user name")
+	cmd.PersistentFlags().StringVarP(&commandeer.password, "password", "w", "", "password")
 
 	// add children
 	cmd.AddCommand(
@@ -118,14 +122,38 @@ func (rc *RootCommandeer) populateConfig(cfg *config.V3ioConfig) error {
 	// TODO: support custom report writers (file, syslog, prometheus, etc.)
 	rc.Reporter = performance.ReporterInstanceFromConfig(cfg)
 
+	if rc.username != "" {
+		cfg.Username = rc.username
+	}
+
+	if rc.password != "" {
+		cfg.Password = rc.password
+	}
+
 	if rc.v3ioPath != "" {
 		// read username and password
 		if i := strings.LastIndex(rc.v3ioPath, "@"); i > 0 {
-			cfg.Username = rc.v3ioPath[0:i]
+			usernameAndPassword := rc.v3ioPath[0:i]
 			rc.v3ioPath = rc.v3ioPath[i+1:]
-			if userpass := strings.Split(cfg.Username, ":"); len(userpass) > 1 {
-				cfg.Username = userpass[0]
-				cfg.Password = userpass[1]
+			if userpass := strings.Split(usernameAndPassword, ":"); len(userpass) > 1 {
+				fmt.Printf("Debug: up0=%s up1=%s u=%s p=%s\n", userpass[0], userpass[1], rc.username, rc.password)
+				if userpass[0] != "" && rc.username != "" {
+					return fmt.Errorf("username should only be defined once")
+				} else {
+					cfg.Username = userpass[0]
+				}
+
+				if userpass[1] != "" && rc.password != "" {
+					return fmt.Errorf("password should only be defined once")
+				} else {
+					cfg.Password = userpass[1]
+				}
+			} else {
+				if usernameAndPassword != "" && rc.username != "" {
+					return fmt.Errorf("username should only be defined once")
+				} else {
+					cfg.Username = usernameAndPassword
+				}
 			}
 		}
 
@@ -178,7 +206,5 @@ func (rc *RootCommandeer) startAdapter() error {
 	}
 
 	rc.logger = rc.adapter.GetLogger("cli")
-
 	return nil
-
 }

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -161,10 +161,10 @@ func (rc *RootCommandeer) populateConfig(cfg *config.V3ioConfig) error {
 		if slash == -1 || len(rc.v3ioPath) <= slash+1 {
 			if rc.container != "" {
 				cfg.Container = rc.container
-				cfg.V3ioUrl = rc.v3ioPath
-			} else {
+			} else if cfg.Container == "" {
 				return fmt.Errorf("missing container name in V3IO URL")
 			}
+			cfg.V3ioUrl = rc.v3ioPath
 		} else {
 			cfg.V3ioUrl = rc.v3ioPath[0:slash]
 			cfg.Container = rc.v3ioPath[slash+1:]

--- a/pkg/utils/misc.go
+++ b/pkg/utils/misc.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+	"github.com/v3io/v3io-go-http"
 	"math"
+	"net/http"
 	"strings"
 )
 
@@ -19,4 +21,17 @@ func FloatToNormalizedScientificStr(val float64) string {
 		return fmt.Sprintf("%f", val)
 	}
 	return strings.Replace(fmt.Sprintf("%e", val), "+", "", 1)
+}
+
+func IsNotExistsError(err error) bool {
+	errorWithStatusCode, ok := err.(v3io.ErrorWithStatusCode)
+	if !ok {
+		// error of different type
+		return false
+	}
+	// Ignore 404s
+	if errorWithStatusCode.StatusCode() == http.StatusNotFound {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
II. CLI Flags
1. Global flags
    * Rename the config-file -c flag to -g (to allow using -c for the container name — see #1.b).
    * Rename the container-identifier -u flag to -c; (depends on #1.a).
    * Separate the username and password from the -s|--server flag (as already done in the configuration file): instead of setting the server flag to “<username>:<password>@<server URL>”, set it to “<server URL>” and add separate username (-u | --username) and password (-w | --password) flags; (depends on #1.b for using -u).
    * Verify that the default value of the -v|--verbose flag should be "debug", as currently set in the code (see #IV.1); the comment for the verbose configuration in the configuration template (pkg/tsdb/testdata/v3io.yaml.template) says that the default value is "info".
    * If the configuration-file flag (-c|--config / -g after #1.a is implemented) isn’t set, don’t return an error if the default configuration file (currently v3io.yaml in the current directory) can’t be loaded (as is currently the case).
If the configuration-file flag is set, require the file-path string (don’t rely on the default path).
2. create command
    * Remove the currently unsupported --sample-retention flag (Bug TSDB-31). --> DONE today (25.9.18). When this flag is returned, rename its -a CLI flag to -r; (depends on #2.b).
    * Rename the -r|--rollups flags to -a|--aggregates; (depends on #2.a).
    * Rename the --rollup-interval flag to --aggregation-granularity; (we can leave the short flag a -i).
3. add command
    * Do not externalize the --delay and --stdin flags; this request was approved f2f by Yaron H..
    * Add an ingest alias.
4. query command
    * Rename the --aggregators flag to --aggregates.
    * Rename the --step flag to --aggregation-interval; (we can leave the short flag a -i)
5. del command — the following changes were agreed upon in a f2f discussion with Golan and Igor:
    * Rename the -f|--force flag to -i|--ignore-errors.
    * Rename the -d|--del-config flag to -a|--all and change the behavior to ignore the -b|--begin and -e|--end flags and always delete the entire table (content & configuration); edit the description accordingly to “Delete the TSDB table (including all content and the configuration schema file)”.  (In the f2f discussion we spoke about renaming the flag to -d|-del-all, but in rethinking it I prefer the new alternative that I suggested here.)
    * Add -f|--force flags to force deletion of the table/partial content and change the behavior so that when this flag isn’t set the command displays an interactive prompt to verify the delete operation (“You are about to delete the <table name> table. Are you sure? (y/n)” or “You are about to delete content from the <table name> table. Are you sure? (y/n)” when the delete-all flag isn’t set); (depends on #5.a for using -f|--force). According to Golan, there might already be an open JIRA ticket to add this option.
6. time command — don’t externalize this command (approved by Golan, Igor, and Yaron H.).