### PR TITLE
Update CLI: change verbose to log-level

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,7 +74,7 @@ type V3ioConfig struct {
 	// Disable is use in Prometheus to disable v3io and work with the internal TSDB
 	Disabled bool `json:"disabled,omitempty"`
 	// Set logging level: debug | info | warn | error (info by default)
-	Verbose string `json:"verbose,omitempty"`
+	LogLevel string `json:"logLevel,omitempty"`
 	// Number of parallel V3IO worker routines
 	Workers int `json:"workers"`
 	// Number of parallel V3IO worker routines for queries (default is min between 8 and Workers)

--- a/pkg/tsdb/testdata/v3io.yaml.template
+++ b/pkg/tsdb/testdata/v3io.yaml.template
@@ -10,7 +10,7 @@ container: <v3io container>
 path: <tsdb path>
 
 # Logging level. Valid values: debug,info,warn,error (Default: info)
-verbose: "warn"
+logLevel: "warn"
 
 # Default timeout 10 seconds
 timeout: 10

--- a/pkg/tsdb/v3iotsdb.go
+++ b/pkg/tsdb/v3iotsdb.go
@@ -47,7 +47,7 @@ type V3ioAdapter struct {
 
 func CreateTSDB(v3iocfg *config.V3ioConfig, schema *config.Schema) error {
 
-	lgr, _ := utils.NewLogger(v3iocfg.Verbose)
+	lgr, _ := utils.NewLogger(v3iocfg.LogLevel)
 	container, err := utils.CreateContainer(
 		lgr, v3iocfg.WebApiEndpoint, v3iocfg.Container, v3iocfg.Username, v3iocfg.Password, v3iocfg.Workers)
 	if err != nil {
@@ -84,7 +84,7 @@ func NewV3ioAdapter(cfg *config.V3ioConfig, container *v3io.Container, logger lo
 	if logger != nil {
 		newV3ioAdapter.logger = logger
 	} else {
-		newV3ioAdapter.logger, err = utils.NewLogger(cfg.Verbose)
+		newV3ioAdapter.logger, err = utils.NewLogger(cfg.LogLevel)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -61,7 +61,7 @@ func NewRootCommandeer() *RootCommandeer {
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
 	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "", "Logging level")
-	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = "debug"
+	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = "info"
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "", "sub path for the TSDB, inside the container")
 	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - ip:port")
 	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "g", "", "path to yaml config file")

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -42,7 +42,7 @@ type RootCommandeer struct {
 	v3ioPath    string
 	dbPath      string
 	cfgFilePath string
-	verbose     string
+	logLevel    string
 	container   string
 	username    string
 	password    string
@@ -60,8 +60,8 @@ func NewRootCommandeer() *RootCommandeer {
 
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
-	cmd.PersistentFlags().StringVarP(&commandeer.verbose, "verbose", "v", "", "Verbose output")
-	cmd.PersistentFlags().Lookup("verbose").NoOptDefVal = "debug"
+	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "", "Logging level")
+	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = "debug"
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "", "sub path for the TSDB, inside the container")
 	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - ip:port")
 	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "g", "", "path to yaml config file")
@@ -175,8 +175,8 @@ func (rc *RootCommandeer) populateConfig(cfg *config.V3ioConfig) error {
 	if cfg.WebApiEndpoint == "" || cfg.Container == "" || cfg.TablePath == "" {
 		return fmt.Errorf("user must provide V3IO URL, container name, and table path via the config file or flags")
 	}
-	if rc.verbose != "" {
-		cfg.Verbose = rc.verbose
+	if rc.logLevel != "" {
+		cfg.LogLevel = rc.logLevel
 	}
 
 	rc.v3iocfg = cfg

--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -30,9 +30,9 @@ import (
 	"time"
 )
 
-func NewLogger(verbose string) (logger.Logger, error) {
+func NewLogger(level string) (logger.Logger, error) {
 	var logLevel nucliozap.Level
-	switch verbose {
+	switch level {
 	case "debug":
 		logLevel = nucliozap.DebugLevel
 	case "info":

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -20,7 +20,7 @@
     path: "tsdb-1"
     
     # Logging level. Valid values: debug,info,warn,error (Default: info)
-    verbose: "warn"
+    logLevel: "warn"
 
     # V3IO Credentials
     username: "<user>@<tenant>"


### PR DESCRIPTION
* Rename `verbose` to `log-level`
* Usage: `-v` for `debug` or `-v=info` for specific level