### PR TITLE
Doc cli log levels

### DIFF
--- a/examples/v3io-tsdb-config.yaml.template
+++ b/examples/v3io-tsdb-config.yaml.template
@@ -14,7 +14,7 @@ webApiEndpoint: "<IP address/host name>:8081"
 # Example: "bigdata"
 container: "<container name>"
 
-# Logging level (for verbose output)
+# Log level
 # Valid values: "debug" | "info" | "warn" | "error"
 logLevel: "warn"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,7 +77,7 @@ type V3ioConfig struct {
 	// Disabled = true disables the V3IO TSDB configuration in Prometheus and
 	// enables the internal Prometheus TSDB instead
 	Disabled bool `json:"disabled,omitempty"`
-	// Logging level (for verbose output) - "debug" | "info" | "warn" | "error"
+	// Log level - "debug" | "info" | "warn" | "error"
 	LogLevel string `json:"logLevel,omitempty"`
 	// Number of parallel V3IO worker routines
 	Workers int `json:"workers"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ const (
 	DefaultAggregationGranularity = "1h"
 	DefaultLayerRetentionTime     = "1y"
 	DefaultSampleRetentionTime    = 0
+	DefaultLogLevel               = "info"
 	DefaultVerboseLevel           = "debug"
 )
 

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -61,7 +61,7 @@ func NewRootCommandeer() *RootCommandeer {
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
 	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "",
-		"Verbose output. You can provide one of the following logging\nlevels as an argument for this flag by using the assignment\noperator ('='): \"debug\" | \"info\" | \"warn\" | \"error\".\nFor example: -v=info. The default log level when using this\nflag without an argument is \""+config.DefaultVerboseLevel+"\".")
+		"Verbose output. You can provide one of the following logging\nlevels as an argument for this flag by using the assignment\noperator ('='): \"debug\" | \"info\" | \"warn\" | \"error\".\nFor example: -v=warn. The default log level when using this\nflag without an argument is \""+config.DefaultVerboseLevel+"\". The default log level\nwhen this flag isn't set is \"" +config.DefaultLogLevel+"\".")
 	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = config.DefaultVerboseLevel
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "",
 		"[Required] Path to the TSDB table within the configured\ndata container. Examples: \"mytsdb\"; \"/my_tsdbs/tsdbd1\".")


### PR DESCRIPTION
- Rephrased the log-level comments (remove verbose-output and default value references + "logging" > "log").
- Edited the `-v|--log-level` help text to document the default log level when the flag isn't set (done using a new `DefaultLogLevel` const) + changed the example from `info` (now the default) to `warn`.