### PR TITLE
[DOC] CLI: Edit log-level help text & comments

### DIFF
--- a/examples/v3io-tsdb-config.yaml.template
+++ b/examples/v3io-tsdb-config.yaml.template
@@ -4,9 +4,9 @@
 # TODO: In your configuration file, delete the configuration keys that you
 #       don't need and replace the "<...>" placeholders.
 
-# Endpoint of an Iguazio Continuous Data Platform web-gateway (web-APIs)
-# service, consisting of an IP address or resolvable host domain name, and a
-# port number (currently, always port 8081)
+# Endpoint of an Iguazio Continuous Data Platform web-gateway (web-API) service,
+# consisting of an IP address or resolvable host domain name, and a port number
+# (currently, always port 8081)
 # Example: "192.168.1.100:8081"
 webApiEndpoint: "<IP address/host name>:8081"
 
@@ -14,11 +14,11 @@ webApiEndpoint: "<IP address/host name>:8081"
 # Example: "bigdata"
 container: "<container name>"
 
-# Logging level (for verbose output)
+# Log level
 # Valid values: "debug" | "info" | "warn" | "error"
 logLevel: "warn"
 
-# Authentication credentials for the web-APIs service
+# Authentication credentials for the web-API service
 username: "<username>"
 password: "<password>"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,7 +77,7 @@ type V3ioConfig struct {
 	// Disabled = true disables the V3IO TSDB configuration in Prometheus and
 	// enables the internal Prometheus TSDB instead
 	Disabled bool `json:"disabled,omitempty"`
-	// Logging level (for verbose output) - "debug" | "info" | "warn" | "error"
+	// Log level - "debug" | "info" | "warn" | "error"
 	LogLevel string `json:"logLevel,omitempty"`
 	// Number of parallel V3IO worker routines
 	Workers int `json:"workers"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ const (
 	DefaultAggregationGranularity = "1h"
 	DefaultLayerRetentionTime     = "1y"
 	DefaultSampleRetentionTime    = 0
+	DefaultLogLevel               = "info"
 	DefaultVerboseLevel           = "debug"
 )
 

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -61,7 +61,7 @@ func NewRootCommandeer() *RootCommandeer {
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
 	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "",
-		"Verbose output. Add \"=<level>\" to set the log level -\ndebug | info | warn | error. For example: -v=warn.\n(default - \""+config.DefaultVerboseLevel+"\" when using the flag and \""+config.DefaultLogLevel+"\" otherwise)")
+		"Verbose output. Add \"=<level>\" to set the log level -\ndebug | info | warn | error. For example: -v=warn.\n(default - \""+config.DefaultVerboseLevel+"\" when using the flag; \""+config.DefaultLogLevel+"\" otherwise)")
 	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = config.DefaultVerboseLevel
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "",
 		"[Required] Path to the TSDB table within the configured\ndata container. Examples: \"mytsdb\"; \"/my_tsdbs/tsdbd1\".")

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -61,7 +61,7 @@ func NewRootCommandeer() *RootCommandeer {
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
 	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "",
-		"Verbose output. You can provide one of the following logging\nlevels as an argument for this flag by using the assignment\noperator ('='): \"debug\" | \"info\" | \"warn\" | \"error\".\nFor example: -v=warn. The default log level when using this\nflag without an argument is \""+config.DefaultVerboseLevel+"\".")
+		"Verbose output. Add \"=<level>\" to set the log level -\ndebug | info | warn | error. For example: -v=warn.\n(default - \""+config.DefaultVerboseLevel+"\" when using the flag and \""+config.DefaultLogLevel+"\" otherwise)")
 	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = config.DefaultVerboseLevel
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "",
 		"[Required] Path to the TSDB table within the configured\ndata container. Examples: \"mytsdb\"; \"/my_tsdbs/tsdbd1\".")

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -61,7 +61,7 @@ func NewRootCommandeer() *RootCommandeer {
 	defaultV3ioServer := os.Getenv("V3IO_SERVICE_URL")
 
 	cmd.PersistentFlags().StringVarP(&commandeer.logLevel, "log-level", "v", "",
-		"Verbose output. You can provide one of the following logging\nlevels as an argument for this flag by using the assignment\noperator ('='): \"debug\" | \"info\" | \"warn\" | \"error\".\nFor example: -v=info. The default log level when using this\nflag without an argument is \""+config.DefaultVerboseLevel+"\".")
+		"Verbose output. You can provide one of the following logging\nlevels as an argument for this flag by using the assignment\noperator ('='): \"debug\" | \"info\" | \"warn\" | \"error\".\nFor example: -v=warn. The default log level when using this\nflag without an argument is \""+config.DefaultVerboseLevel+"\".")
 	cmd.PersistentFlags().Lookup("log-level").NoOptDefVal = config.DefaultVerboseLevel
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "",
 		"[Required] Path to the TSDB table within the configured\ndata container. Examples: \"mytsdb\"; \"/my_tsdbs/tsdbd1\".")

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -192,7 +192,7 @@ func (rc *RootCommandeer) populateConfig(cfg *config.V3ioConfig) error {
 	if rc.logLevel != "" {
 		cfg.LogLevel = rc.logLevel
 	} else {
-		cfg.LogLevel = "info"
+		cfg.LogLevel = config.DefaultLogLevel
 	}
 
 	rc.v3iocfg = cfg


### PR DESCRIPTION
PR #170 take 2

This is the updated help output:
```
-v, --log-level string[="debug"]   Verbose output. Add "=<level>" to set the log level -
                                   debug | info | warn | error. For example: -v=warn.
                                   (default - "debug" when using the flag; "info" otherwise) 
```

@gshatz If you're still not willing to merge all commits, let's talk before you close the PR.