### PR TITLE
Fix prometheus not showing all wanted series

### DIFF
--- a/pkg/querier/multipart.go
+++ b/pkg/querier/multipart.go
@@ -92,7 +92,7 @@ func (im *IterSortMerger) Next() bool {
 		return false
 	}
 
-	im.currSeries = im.currSeries[:0]
+	im.currSeries = make([]Series, 0, len(im.iters))
 	for i, iter := range im.iters {
 		im.currInvalids[i] = true
 		if !im.done[i] {


### PR DESCRIPTION
`iterSortMerge` used to return reference to the same object for each series which meant that all "series" pointed to the same data and prometheus reduced them to one series on the graph.
Note: This happened only when using `iterSortMerge` which means only when the query is on multiple partitions