### PR TITLE
TSDB-49: Fix issue in MIN/MAX aggregates

### DIFF
--- a/pkg/querier/series.go
+++ b/pkg/querier/series.go
@@ -280,7 +280,7 @@ func (s *aggrSeriesIterator) Next() bool {
 }
 
 func (s *aggrSeriesIterator) getNextValidCell(from int) (nextIndex int) {
-	for nextIndex = from + 1; nextIndex <= s.aggrSet.GetMaxCell() && !s.aggrSet.DoesCellHaveData(nextIndex); nextIndex++ {
+	for nextIndex = from + 1; nextIndex <= s.aggrSet.GetMaxCell() && !s.aggrSet.HasData(nextIndex); nextIndex++ {
 	}
 	return
 }

--- a/pkg/tsdb/tsdbtest/tsdbtest.go
+++ b/pkg/tsdb/tsdbtest/tsdbtest.go
@@ -47,7 +47,11 @@ func DeleteTSDB(t testing.TB, v3ioConfig *config.V3ioConfig) {
 }
 
 func CreateTestTSDB(t testing.TB, v3ioConfig *config.V3ioConfig) {
-	schema := testutils.CreateSchema(t, "*")
+	CreateTestTSDBWithAggregates(t, v3ioConfig, "*")
+}
+
+func CreateTestTSDBWithAggregates(t testing.TB, v3ioConfig *config.V3ioConfig, aggregates string) {
+	schema := testutils.CreateSchema(t, aggregates)
 	if err := CreateTSDB(v3ioConfig, schema); err != nil {
 		v3ioConfigAsJson, _ := json2.MarshalIndent(v3ioConfig, "", "  ")
 		t.Fatalf("Failed to create a TSDB instance (table). Reason: %v\nConfiguration:\n%s", err, string(v3ioConfigAsJson))


### PR DESCRIPTION
 - do not use memset-like trick but only COUNT to identify the state of cell
 - add tests
 - replaces #185 

Bug: TSDB-49