### PR TITLE
Switch CI to an alternate cloud system

### DIFF
--- a/travis_v3io.yaml
+++ b/travis_v3io.yaml
@@ -1,5 +1,5 @@
 container: "bigdata"
 workers: 1
-webApiEndpoint: "webapi.iguazio.app.tsdb-integration.dev.trl.iguazio.com:8081"
+webApiEndpoint: "webapi.iguazio.app.tsdb-integration-alternate.dev.trl.iguazio.com:8081"
 username: "iguazio"
 password: "99c11228cf25d9093a7c11eeac147114"


### PR DESCRIPTION
as the original's data node became unreachable at 9am (Israel Time) today, and we want to keep it up for diagnostic purposes.