### PR TITLE
TSDB-52: Fix partial partition delete 

### DIFF
--- a/pkg/partmgr/partmgr.go
+++ b/pkg/partmgr/partmgr.go
@@ -279,7 +279,7 @@ func (p *PartitionManager) updatePartitionsFromSchema(schema *config.Schema) err
 	return nil
 }
 
-//if inclusive is true than partial partitions (not fully in range) will be retireved
+//if inclusive is true than partial partitions (not fully in range) will be retireved as well
 func (p *PartitionManager) PartsForRange(mint, maxt int64, inclusive bool) []*DBPartition {
 	var parts []*DBPartition
 	for _, part := range p.partitions {

--- a/pkg/partmgr/partmgr.go
+++ b/pkg/partmgr/partmgr.go
@@ -279,10 +279,11 @@ func (p *PartitionManager) updatePartitionsFromSchema(schema *config.Schema) err
 	return nil
 }
 
-func (p *PartitionManager) PartsForRange(mint, maxt int64) []*DBPartition {
+//if inclusive is true than partial partitions (not fully in range) will be retireved
+func (p *PartitionManager) PartsForRange(mint, maxt int64, inclusive bool) []*DBPartition {
 	var parts []*DBPartition
 	for _, part := range p.partitions {
-		if part.InRange(mint) || part.InRange(maxt) || (mint < part.GetStartTime() && maxt > part.GetEndTime()) {
+		if (mint < part.GetStartTime() && maxt > part.GetEndTime()) || (inclusive && (part.InRange(mint) || part.InRange(maxt))) {
 			parts = append(parts, part)
 		}
 	}

--- a/pkg/partmgr/partmgr_test.go
+++ b/pkg/partmgr/partmgr_test.go
@@ -104,16 +104,16 @@ func TestPartsForRange(tst *testing.T) {
 	}
 	assert.Equal(tst, numPartitions, len(manager.partitions))
 	// Get all partitions
-	assert.Equal(tst, manager.partitions, manager.PartsForRange(0, interval*int64(numPartitions+1)))
+	assert.Equal(tst, manager.partitions, manager.PartsForRange(0, interval*int64(numPartitions+1), true))
 	// Get no partitions
-	assert.Equal(tst, 0, len(manager.PartsForRange(0, interval-1)))
+	assert.Equal(tst, 0, len(manager.PartsForRange(0, interval-1)), true)
 	// Get the first 2 partitions
-	parts := manager.PartsForRange(0, interval*2+1)
+	parts := manager.PartsForRange(0, interval*2+1, true)
 	assert.Equal(tst, 2, len(parts))
 	assert.Equal(tst, manager.partitions[0], parts[0])
 	assert.Equal(tst, manager.partitions[1], parts[1])
 	// Get the middle 3 partitions
-	parts = manager.PartsForRange(interval*2, interval*4+1)
+	parts = manager.PartsForRange(interval*2, interval*4+1, true)
 	assert.Equal(tst, 3, len(parts))
 	assert.Equal(tst, manager.partitions[1], parts[0])
 	assert.Equal(tst, manager.partitions[2], parts[1])

--- a/pkg/partmgr/partmgr_test.go
+++ b/pkg/partmgr/partmgr_test.go
@@ -106,7 +106,7 @@ func TestPartsForRange(tst *testing.T) {
 	// Get all partitions
 	assert.Equal(tst, manager.partitions, manager.PartsForRange(0, interval*int64(numPartitions+1), true))
 	// Get no partitions
-	assert.Equal(tst, 0, len(manager.PartsForRange(0, interval-1)), true)
+	assert.Equal(tst, 0, len(manager.PartsForRange(0, interval-1, true)), true)
 	// Get the first 2 partitions
 	parts := manager.PartsForRange(0, interval*2+1, true)
 	assert.Equal(tst, 2, len(parts))
@@ -118,6 +118,15 @@ func TestPartsForRange(tst *testing.T) {
 	assert.Equal(tst, manager.partitions[1], parts[0])
 	assert.Equal(tst, manager.partitions[2], parts[1])
 	assert.Equal(tst, manager.partitions[3], parts[2])
+	// Get the middle partition by inclusive=false
+	parts = manager.PartsForRange(interval*2+1, interval*4+1, false)
+	assert.Equal(tst, 1, len(parts))
+	assert.Equal(tst, manager.partitions[2], parts[0])
+	// Get the middle partition by inclusive=false
+	parts = manager.PartsForRange(interval*2-1, interval*4+1, false)
+	assert.Equal(tst, 2, len(parts))
+	assert.Equal(tst, manager.partitions[1], parts[0])
+	assert.Equal(tst, manager.partitions[2], parts[1])
 }
 
 func TestTime2Bucket(tst *testing.T) {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -102,7 +102,7 @@ func (q *V3ioQuerier) selectQry(
 	q.performanceReporter.WithTimer("QueryTimer", func() {
 		filter = strings.Replace(filter, "__name__", "_name", -1)
 
-		parts := q.partitionMngr.PartsForRange(q.mint, q.maxt)
+		parts := q.partitionMngr.PartsForRange(q.mint, q.maxt, true)
 		if len(parts) == 0 {
 			return
 		}

--- a/pkg/tsdb/v3iotsdb.go
+++ b/pkg/tsdb/v3iotsdb.go
@@ -202,18 +202,15 @@ func (a *V3ioAdapter) DeleteDB(deleteAll bool, ignoreErrors bool, fromTime int64
 
 	partitions := a.partitionMngr.PartsForRange(fromTime, toTime, false)
 	for _, part := range partitions {
-		pStart, pEnd := part.GetPartitionRange()
-		if pStart >= fromTime && pEnd <= toTime {
-			a.logger.Info("Delete partition '%s'.", part.GetTablePath())
-			err := utils.DeleteTable(a.logger, a.container, part.GetTablePath(), "", a.cfg.QryWorkers)
-			if err != nil && !ignoreErrors {
-				return errors.Wrapf(err, "Failed to delete partition '%s'.", part.GetTablePath())
-			}
-			// Delete the Directory object
-			err = a.container.Sync.DeleteObject(&v3io.DeleteObjectInput{Path: part.GetTablePath()})
-			if err != nil && !ignoreErrors {
-				return errors.Wrapf(err, "Failed to delete partition object '%s'.", part.GetTablePath())
-			}
+		a.logger.Info("Deleting partition '%s'.", part.GetTablePath())
+		err := utils.DeleteTable(a.logger, a.container, part.GetTablePath(), "", a.cfg.QryWorkers)
+		if err != nil && !ignoreErrors {
+			return errors.Wrapf(err, "Failed to delete partition '%s'.", part.GetTablePath())
+		}
+		// Delete the Directory object
+		err = a.container.Sync.DeleteObject(&v3io.DeleteObjectInput{Path: part.GetTablePath()})
+		if err != nil && !ignoreErrors {
+			return errors.Wrapf(err, "Failed to delete partition object '%s'.", part.GetTablePath())
 		}
 	}
 	a.partitionMngr.DeletePartitionsFromSchema(partitions)

--- a/pkg/tsdb/v3iotsdb.go
+++ b/pkg/tsdb/v3iotsdb.go
@@ -200,7 +200,7 @@ func (a *V3ioAdapter) DeleteDB(deleteAll bool, ignoreErrors bool, fromTime int64
 		toTime = time.Now().Unix() * 1000
 	}
 
-	partitions := a.partitionMngr.PartsForRange(fromTime, toTime)
+	partitions := a.partitionMngr.PartsForRange(fromTime, toTime, false)
 	for _, part := range partitions {
 		pStart, pEnd := part.GetPartitionRange()
 		if pStart >= fromTime && pEnd <= toTime {

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -637,50 +637,50 @@ func TestDeleteTable(t *testing.T) {
 		ignoreReason string
 	}{
 		{desc: "Should delete all table",
-			deleteFrom:     0,
-			deleteTo:       1599999999999,
-			ignoreErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			deleteFrom:   0,
+			deleteTo:     1599999999999,
+			ignoreErrors: true,
+			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1538925653000, Value: 333.3},
 				{Time: 1539271253000, Value: 444.4}},
-			expected:		[]tsdbtest.DataPoint{},
+			expected: []tsdbtest.DataPoint{},
 		},
 		{desc: "Should skip partial partition at begining",
-			deleteFrom:     1538580050000,
-			deleteTo:       1999271259000,
-			ignoreErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			deleteFrom:   1538580050000,
+			deleteTo:     1999271259000,
+			ignoreErrors: true,
+			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1538925653000, Value: 333.3},
 				{Time: 1539271253000, Value: 444.4}},
-			expected:     	[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2}},
+			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2}},
 		},
 		{desc: "Should skip partial partition at end",
-			deleteFrom:     0,
-			deleteTo:       1539271259000,
-			ignoreErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			deleteFrom:   0,
+			deleteTo:     1539271259000,
+			ignoreErrors: true,
+			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1538925653000, Value: 333.3},
 				{Time: 1539271253000, Value: 444.4}},
-			expected:     	[]tsdbtest.DataPoint{{Time: 1539271253000, Value: 444.4}},
+			expected: []tsdbtest.DataPoint{{Time: 1539271253000, Value: 444.4}},
 		},
 		{desc: "Should skip partial partition at beginning and end not in range",
-			deleteFrom:     1538580054000,
-			deleteTo:       1539271252000,
-			ignoreErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			deleteFrom:   1538580054000,
+			deleteTo:     1539271252000,
+			ignoreErrors: true,
+			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1538925653000, Value: 333.3},
 				{Time: 1539271253000, Value: 444.4}},
-			expected:     	[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1539271253000, Value: 444.4}},
 		},
 		{desc: "Should skip partial partition at beginning and end although in range",
-			deleteFrom:     1538580050000,
-			deleteTo:       1539271259000,
-			ignoreErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			deleteFrom:   1538580050000,
+			deleteTo:     1539271259000,
+			ignoreErrors: true,
+			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1538925653000, Value: 333.3},
 				{Time: 1539271253000, Value: 444.4}},
-			expected:     	[]tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
+			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
 				{Time: 1539271253000, Value: 444.4}},
 		},
 	}
@@ -690,24 +690,22 @@ func TestDeleteTable(t *testing.T) {
 			if test.ignoreReason != "" {
 				t.Skip(test.ignoreReason)
 			}
-			testDeleteTSDBCase(t, v3ioConfig, "metricToDelete", utils.LabelsFromStrings("os","linux"),
+			testDeleteTSDBCase(t, v3ioConfig, "metricToDelete", utils.LabelsFromStrings("os", "linux"),
 				test.data, test.deleteFrom, test.deleteTo, test.ignoreErrors, test.expected)
 		})
 	}
 }
 
-
 func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsName string, userLabels []utils.Label,
 	data []tsdbtest.DataPoint, deleteFrom int64, deleteTo int64, ignoreErrors bool,
 	expected []tsdbtest.DataPoint) {
-
 
 	adapter, teardown := tsdbtest.SetUpWithData(test, v3ioConfig, metricsName, data, userLabels)
 	defer teardown()
 
 	pm, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, v3ioConfig)
 
-	initiaPartitions := pm.PartsForRange(0, time.Now().Unix() * 1000, true)
+	initiaPartitions := pm.PartsForRange(0, time.Now().Unix()*1000, true)
 	initialNumberOfPartitions := len(initiaPartitions)
 
 	partitionsToDelete := pm.PartsForRange(deleteFrom, deleteTo, false)
@@ -717,10 +715,10 @@ func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsN
 	}
 
 	pm1, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, v3ioConfig)
-	remainingParts := pm1.PartsForRange(0, time.Now().Unix() * 1000, false)
-	assert.Equal(test, len(remainingParts),  initialNumberOfPartitions - len(partitionsToDelete))
+	remainingParts := pm1.PartsForRange(0, time.Now().Unix()*1000, false)
+	assert.Equal(test, len(remainingParts), initialNumberOfPartitions-len(partitionsToDelete))
 
-	qry, err := adapter.Querier(nil, 0, time.Now().Unix() * 1000)
+	qry, err := adapter.Querier(nil, 0, time.Now().Unix()*1000)
 	if err != nil {
 		test.Fatalf("Failed to create Querier. reason: %v", err)
 	}

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -637,12 +637,12 @@ func TestDeleteTable(t *testing.T) {
 		expectFail   bool
 	}{
 		{desc: "Should delete all table",
-			deleteFrom:     1522222999,
-			deleteTo:       1544444000,
+			deleteFrom:     1522222999000,
+			deleteTo:       1544444000000,
 			ignorErrors:	true,
-			data:     		[]tsdbtest.DataPoint{{Time: 1522222222, Value: 222.2},
-												{Time: 1533333333, Value: 333.3},
-												{Time: 1544444444, Value: 444.4}},
+			data:     		[]tsdbtest.DataPoint{{Time: 1522222222000, Value: 222.2},
+												{Time: 1533333333000, Value: 333.3},
+												{Time: 1544444444000, Value: 444.4}},
 			expected:		map[string][]tsdbtest.DataPoint{},
 			expectFail: 	true,
 		},
@@ -692,16 +692,22 @@ func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsN
 	}
 
 	series := set.At()
-	iter := series.Iterator()
-	if iter.Err() != nil {
-		test.Fatalf("Failed to query data series. reason: %v", iter.Err())
-	}
+	if series == nil && len(expected) == 0 {
+		//table is expected to be empty
+	} else if series != nil {
+		iter := series.Iterator()
+		if iter.Err() != nil {
+			test.Fatalf("Failed to query data series. reason: %v", iter.Err())
+		}
 
-	actual, err := iteratorToSlice(iter)
-	if err != nil {
-		test.Fatal(err)
+		actual, err := iteratorToSlice(iter)
+		if err != nil {
+			test.Fatal(err)
+		}
+		assert.ElementsMatch(test, expected["1"], actual)
+	} else {
+		test.Fatalf("Result series is empty while expected result set is not!")
 	}
-	assert.ElementsMatch(test, expected["1"], actual)
 }
 
 func iteratorToSlice(it chunkenc.Iterator) ([]tsdbtest.DataPoint, error) {

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -626,6 +626,13 @@ func TestDeleteTable(t *testing.T) {
 		t.Fatalf("unable to load configuration. Error: %v", err)
 	}
 
+	ta,_ := time.Parse(time.RFC3339, "2018-10-03T05:00:00Z")
+	t1 := ta.Unix()*1000
+	tb,_ := time.Parse(time.RFC3339, "2018-10-07T05:00:00Z")
+	t2 := tb.Unix()*1000
+	tc,_ := time.Parse(time.RFC3339, "2018-10-11T05:00:00Z")
+	t3 :=  tc.Unix()*1000
+
 	testCases := []struct {
 		desc         string
 		deleteFrom   int64
@@ -638,50 +645,50 @@ func TestDeleteTable(t *testing.T) {
 	}{
 		{desc: "Should delete all table",
 			deleteFrom:   0,
-			deleteTo:     1599999999999,
+			deleteTo: 	  9999999999999,
 			ignoreErrors: true,
-			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1538925653000, Value: 333.3},
-				{Time: 1539271253000, Value: 444.4}},
+			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t2, Value: 333.3},
+				{Time: t3, Value: 444.4}},
 			expected: []tsdbtest.DataPoint{},
 		},
 		{desc: "Should skip partial partition at begining",
-			deleteFrom:   1538580050000,
-			deleteTo:     1999271259000,
+			deleteFrom:   t1 - 10000,
+			deleteTo:     9999999999999,
 			ignoreErrors: true,
-			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1538925653000, Value: 333.3},
-				{Time: 1539271253000, Value: 444.4}},
-			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2}},
+			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t2, Value: 333.3},
+				{Time: t3, Value: 444.4}},
+			expected: []tsdbtest.DataPoint{{Time: t1, Value: 222.2}},
 		},
 		{desc: "Should skip partial partition at end",
 			deleteFrom:   0,
-			deleteTo:     1539271259000,
+			deleteTo:     t3 + 10000,
 			ignoreErrors: true,
-			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1538925653000, Value: 333.3},
-				{Time: 1539271253000, Value: 444.4}},
-			expected: []tsdbtest.DataPoint{{Time: 1539271253000, Value: 444.4}},
+			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t2, Value: 333.3},
+				{Time: t3, Value: 444.4}},
+			expected: []tsdbtest.DataPoint{{Time: t3, Value: 444.4}},
 		},
 		{desc: "Should skip partial partition at beginning and end not in range",
-			deleteFrom:   1538580054000,
-			deleteTo:     1539271252000,
+			deleteFrom:   t1 + 10000,
+			deleteTo:     t3 - 10000,
 			ignoreErrors: true,
-			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1538925653000, Value: 333.3},
-				{Time: 1539271253000, Value: 444.4}},
-			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1539271253000, Value: 444.4}},
+			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t2, Value: 333.3},
+				{Time: t3, Value: 444.4}},
+			expected: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t3, Value: 444.4}},
 		},
 		{desc: "Should skip partial partition at beginning and end although in range",
-			deleteFrom:   1538580050000,
-			deleteTo:     1539271259000,
+			deleteFrom:   t1 - 10000,
+			deleteTo:     t3 + 10000,
 			ignoreErrors: true,
-			data: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1538925653000, Value: 333.3},
-				{Time: 1539271253000, Value: 444.4}},
-			expected: []tsdbtest.DataPoint{{Time: 1538580053000, Value: 222.2},
-				{Time: 1539271253000, Value: 444.4}},
+			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t2, Value: 333.3},
+				{Time: t3, Value: 444.4}},
+			expected: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
+				{Time: t3, Value: 444.4}},
 		},
 	}
 

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -626,12 +626,12 @@ func TestDeleteTable(t *testing.T) {
 		t.Fatalf("unable to load configuration. Error: %v", err)
 	}
 
-	ta,_ := time.Parse(time.RFC3339, "2018-10-03T05:00:00Z")
-	t1 := ta.Unix()*1000
-	tb,_ := time.Parse(time.RFC3339, "2018-10-07T05:00:00Z")
-	t2 := tb.Unix()*1000
-	tc,_ := time.Parse(time.RFC3339, "2018-10-11T05:00:00Z")
-	t3 :=  tc.Unix()*1000
+	ta, _ := time.Parse(time.RFC3339, "2018-10-03T05:00:00Z")
+	t1 := ta.Unix() * 1000
+	tb, _ := time.Parse(time.RFC3339, "2018-10-07T05:00:00Z")
+	t2 := tb.Unix() * 1000
+	tc, _ := time.Parse(time.RFC3339, "2018-10-11T05:00:00Z")
+	t3 := tc.Unix() * 1000
 
 	testCases := []struct {
 		desc         string
@@ -645,7 +645,7 @@ func TestDeleteTable(t *testing.T) {
 	}{
 		{desc: "Should delete all table",
 			deleteFrom:   0,
-			deleteTo: 	  9999999999999,
+			deleteTo:     9999999999999,
 			ignoreErrors: true,
 			data: []tsdbtest.DataPoint{{Time: t1, Value: 222.2},
 				{Time: t2, Value: 333.3},

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -129,7 +129,7 @@ func (dc *delCommandeer) delete() error {
 
 	err = dc.rootCommandeer.adapter.DeleteDB(dc.deleteAll, dc.ignoreErrors, from, to)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to delete%s TSDB table '%s' in container '%s'.", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
+		return errors.Wrapf(err, "Failed to delete %s TSDB table '%s' in container '%s'.", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 	}
 	fmt.Printf("Successfully deleted %s TSDB table '%s' from container '%s'.\n", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -117,7 +117,7 @@ func (dc *delCommandeer) delete() error {
 	}
 	if !dc.force {
 		confirmedByUser, err := getConfirmation(
-			fmt.Sprintf("You are about to delete%s TSDB table '%s' in container '%s'. Are you sure?", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container))
+			fmt.Sprintf("You are about to delete %s TSDB table '%s' in container '%s'. Are you sure?", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container))
 		if err != nil {
 			return err
 		}

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -72,7 +72,7 @@ Notes:
 
 	cmd.Flags().BoolVarP(&commandeer.deleteAll, "all", "a", false,
 		"Delete the TSDB table, including its configuration and all content.")
-	cmd.Flags().BoolVarP(&commandeer.ignoreErrors, "ignore-errors", "i", false,
+	cmd.Flags().BoolVarP(&commandeer.ignoreErrors, "ignore-errors", "i", true,
 		"Ignore errors - continue deleting even if some steps fail.")
 	cmd.Flags().BoolVarP(&commandeer.force, "force", "f", false,
 		"Forceful deletion - don't display a delete-verification prompt.")

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -111,9 +111,13 @@ func (dc *delCommandeer) delete() error {
 		}
 	}
 
+	partialMsg := ""
+	if !dc.deleteAll {
+		partialMsg = " part of"
+	}
 	if !dc.force {
 		confirmedByUser, err := getConfirmation(
-			fmt.Sprintf("You are about to delete TSDB table '%s' in container '%s'. Are you sure?", dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container))
+			fmt.Sprintf("You are about to delete%s TSDB table '%s' in container '%s'. Are you sure?", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container))
 		if err != nil {
 			return err
 		}
@@ -125,9 +129,9 @@ func (dc *delCommandeer) delete() error {
 
 	err = dc.rootCommandeer.adapter.DeleteDB(dc.deleteAll, dc.ignoreErrors, from, to)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to delete TSDB table '%s' in container '%s'.", dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
+		return errors.Wrapf(err, "Failed to delete%s TSDB table '%s' in container '%s'.", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 	}
-	fmt.Printf("Successfully deleted TSDB table '%s' from container '%s'.\n", dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
+	fmt.Printf("Successfully deleted%s TSDB table '%s' from container '%s'.\n", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 
 	return nil
 }

--- a/pkg/tsdbctl/delete.go
+++ b/pkg/tsdbctl/delete.go
@@ -111,9 +111,9 @@ func (dc *delCommandeer) delete() error {
 		}
 	}
 
-	partialMsg := ""
+	partialMsg := "entire"
 	if !dc.deleteAll {
-		partialMsg = " part of"
+		partialMsg = "part of"
 	}
 	if !dc.force {
 		confirmedByUser, err := getConfirmation(
@@ -131,7 +131,7 @@ func (dc *delCommandeer) delete() error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to delete%s TSDB table '%s' in container '%s'.", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 	}
-	fmt.Printf("Successfully deleted%s TSDB table '%s' from container '%s'.\n", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
+	fmt.Printf("Successfully deleted %s TSDB table '%s' from container '%s'.\n", partialMsg, dc.rootCommandeer.v3iocfg.TablePath, dc.rootCommandeer.v3iocfg.Container)
 
 	return nil
 }


### PR DESCRIPTION
1. change the default of ignoreErrors to true
2. delete only partitions that completely (not partialy) in the range for delete