### PR TITLE
Add configuration HTTP timeout. Default is 10 seconds.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,8 @@ type V3ioConfig struct {
 	Username       string `json:"username,omitempty"`
 	Password       string `json:"password,omitempty"`
 
+	HttpTimeout string `json:"httpTimeout,omitempty"`
+
 	// Disabled = true disables the V3IO TSDB configuration in Prometheus and
 	// enables the internal Prometheus TSDB instead
 	Disabled bool `json:"disabled,omitempty"`

--- a/pkg/tsdb/v3iotsdb.go
+++ b/pkg/tsdb/v3iotsdb.go
@@ -49,8 +49,7 @@ type V3ioAdapter struct {
 func CreateTSDB(v3iocfg *config.V3ioConfig, schema *config.Schema) error {
 
 	lgr, _ := utils.NewLogger(v3iocfg.LogLevel)
-	container, err := utils.CreateContainer(
-		lgr, v3iocfg.WebApiEndpoint, v3iocfg.Container, v3iocfg.Username, v3iocfg.Password, v3iocfg.Workers)
+	container, err := utils.CreateContainer(lgr, v3iocfg)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create a data container.")
 	}
@@ -94,8 +93,7 @@ func NewV3ioAdapter(cfg *config.V3ioConfig, container *v3io.Container, logger lo
 	if container != nil {
 		newV3ioAdapter.container = container
 	} else {
-		newV3ioAdapter.container, err = utils.CreateContainer(newV3ioAdapter.logger,
-			cfg.WebApiEndpoint, cfg.Container, cfg.Username, cfg.Password, cfg.Workers)
+		newV3ioAdapter.container, err = utils.CreateContainer(newV3ioAdapter.logger, cfg)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to create V3IO data container")
 		}

--- a/vendor/github.com/v3io/v3io-go-http/synccontext.go
+++ b/vendor/github.com/v3io/v3io-go-http/synccontext.go
@@ -1,6 +1,8 @@
 package v3io
 
 import (
+	"time"
+
 	"github.com/nuclio/logger"
 	"github.com/valyala/fasthttp"
 )
@@ -9,6 +11,7 @@ type SyncContext struct {
 	logger     logger.Logger
 	httpClient *fasthttp.HostClient
 	clusterURL string
+	Timeout    time.Duration
 }
 
 func newSyncContext(parentLogger logger.Logger, clusterURL string) (*SyncContext, error) {
@@ -25,10 +28,9 @@ func newSyncContext(parentLogger logger.Logger, clusterURL string) (*SyncContext
 
 func (sc *SyncContext) sendRequest(request *fasthttp.Request, response *fasthttp.Response) error {
 
-	err := sc.httpClient.Do(request, response)
-	if err != nil {
-		return err
+	if sc.Timeout <= 0 {
+		return sc.httpClient.Do(request, response)
+	} else {
+		return sc.httpClient.DoTimeout(request, response, sc.Timeout)
 	}
-
-	return nil
 }

--- a/vendor/github.com/v3io/v3io-go-http/types.go
+++ b/vendor/github.com/v3io/v3io-go-http/types.go
@@ -31,6 +31,7 @@ type Request struct {
 	// pointer to container
 	requestResponse *RequestResponse
 
+	// Request time
 	SendTimeNanoseconds int64
 }
 


### PR DESCRIPTION
Updated vendorized v3io-go-http to get timeout support.