### PR TITLE
Use `tsdbtest.TestParams` to control the input params and flow of an integration test

### DIFF
--- a/examples/nuclio/ingest/ingest_example_integration_test.go
+++ b/examples/nuclio/ingest/ingest_example_integration_test.go
@@ -11,11 +11,10 @@ import (
 )
 
 func TestIngestIntegration(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-	defer tsdbtest.SetUp(t, v3ioConfig)()
+	testParams := tsdbtest.NewTestParams(t)
+	defer tsdbtest.SetUp(t, testParams)()
+
+	v3ioConfig := testParams.V3ioConfig()
 	tsdbConfig = fmt.Sprintf(`path: "%v"`, v3ioConfig.TablePath)
 
 	url := os.Getenv("V3IO_SERVICE_URL")

--- a/examples/nuclio/query/query_example_integration_test.go
+++ b/examples/nuclio/query/query_example_integration_test.go
@@ -11,11 +11,10 @@ import (
 )
 
 func TestQueryIntegration(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-	defer tsdbtest.SetUp(t, v3ioConfig)()
+	testParams := tsdbtest.NewTestParams(t)
+	defer tsdbtest.SetUp(t, testParams)()
+
+	v3ioConfig := testParams.V3ioConfig()
 	tsdbConfig = fmt.Sprintf(`path: "%v"`, v3ioConfig.TablePath)
 
 	url := os.Getenv("V3IO_SERVICE_URL")

--- a/pkg/tsdb/tsdb_integration_test.go
+++ b/pkg/tsdb/tsdb_integration_test.go
@@ -37,13 +37,11 @@ type testTsdbSuite struct {
 }
 
 func (suite *testTsdbSuite) TestAppend() {
+	testCtx := suite.T()
+	testParams := tsdbtest.NewTestParams(testCtx)
+	defer tsdbtest.SetUp(testCtx, testParams)()
 
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	suite.Require().NoError(err)
-
-	defer tsdbtest.SetUp(suite.T(), v3ioConfig)()
-
-	adapter, err := tsdb.NewV3ioAdapter(v3ioConfig, nil, nil)
+	adapter, err := tsdb.NewV3ioAdapter(testParams.V3ioConfig(), nil, nil)
 	suite.Require().NoError(err)
 
 	appender, err := adapter.Appender()

--- a/pkg/tsdb/tsdbtest/tsdbtest.go
+++ b/pkg/tsdb/tsdbtest/tsdbtest.go
@@ -38,7 +38,7 @@ type TestOption struct {
 	Value interface{}
 }
 
-func NewTestParams(t testing.TB, opts ... TestOption) TestParams {
+func NewTestParams(t testing.TB, opts ...TestOption) TestParams {
 	initialSize := len(opts)
 	testOpts := make(TestParams, initialSize)
 
@@ -51,6 +51,8 @@ func NewTestParams(t testing.TB, opts ... TestOption) TestParams {
 	if err != nil {
 		t.Fatalf("Unable to get V3IO configuration.\nError: %v", err)
 	}
+
+	//defaultV3ioConfig.TablePath = PrefixTablePath(t.Name())
 	testOpts[OptV3ioConfig] = defaultV3ioConfig
 
 	for _, opt := range opts {

--- a/pkg/tsdb/tsdbtest/tsdbtest.go
+++ b/pkg/tsdb/tsdbtest/tsdbtest.go
@@ -20,6 +20,58 @@ type DataPoint struct {
 	Time  int64
 	Value float64
 }
+type Metric struct {
+	Name   string
+	Labels utils.Labels
+	Data   []DataPoint
+}
+type TimeSeries []Metric
+
+const OptDropTableOnTearDown = "DropTableOnTearDown"
+const OptIgnoreReason = "IgnoreReason"
+const OptTimeSeries = "TimeSeries"
+const OptV3ioConfig = "V3ioConfig"
+
+type TestParams map[string]interface{}
+type TestOption struct {
+	Key   string
+	Value interface{}
+}
+
+func NewTestParams(t testing.TB, opts ... TestOption) TestParams {
+	initialSize := len(opts)
+	testOpts := make(TestParams, initialSize)
+
+	// Initialize defaults
+	testOpts[OptDropTableOnTearDown] = true
+	testOpts[OptIgnoreReason] = ""
+	testOpts[OptTimeSeries] = TimeSeries{}
+
+	defaultV3ioConfig, err := LoadV3ioConfig()
+	if err != nil {
+		t.Fatalf("Unable to get V3IO configuration.\nError: %v", err)
+	}
+	testOpts[OptV3ioConfig] = defaultV3ioConfig
+
+	for _, opt := range opts {
+		testOpts[opt.Key] = opt.Value
+	}
+
+	return testOpts
+}
+
+func (tp TestParams) TimeSeries() TimeSeries {
+	return tp[OptTimeSeries].(TimeSeries)
+}
+func (tp TestParams) DropTableOnTearDown() bool {
+	return tp[OptDropTableOnTearDown].(bool)
+}
+func (tp TestParams) IgnoreReason() string {
+	return tp[OptIgnoreReason].(string)
+}
+func (tp TestParams) V3ioConfig() *config.V3ioConfig {
+	return tp[OptV3ioConfig].(*config.V3ioConfig)
+}
 
 // DataPointTimeSorter sorts DataPoints by time
 type DataPointTimeSorter []DataPoint
@@ -58,7 +110,15 @@ func CreateTestTSDBWithAggregates(t testing.TB, v3ioConfig *config.V3ioConfig, a
 	}
 }
 
-func SetUp(t testing.TB, v3ioConfig *config.V3ioConfig) func() {
+func tearDown(t testing.TB, v3ioConfig *config.V3ioConfig, testParams TestParams) {
+	// Don't delete the TSDB table if the test failed or test expects that
+	if !t.Failed() && testParams.DropTableOnTearDown() {
+		DeleteTSDB(t, v3ioConfig)
+	}
+}
+
+func SetUp(t testing.TB, testParams TestParams) func() {
+	v3ioConfig := testParams.V3ioConfig()
 	v3ioConfig.TablePath = PrefixTablePath(fmt.Sprintf("%s-%d", t.Name(), time.Now().Nanosecond()))
 	CreateTestTSDB(t, v3ioConfig)
 
@@ -71,20 +131,18 @@ func SetUp(t testing.TB, v3ioConfig *config.V3ioConfig) func() {
 
 	return func() {
 		defer metricReporter.Stop()
-		// Don't delete the TSDB table if the test failed
-		if !t.Failed() && !t.Skipped() {
-			DeleteTSDB(t, v3ioConfig)
-		}
+		tearDown(t, v3ioConfig, testParams)
 	}
 }
 
-func SetUpWithData(t *testing.T, v3ioConfig *config.V3ioConfig, metricName string, data []DataPoint, userLabels utils.Labels) (*V3ioAdapter, func()) {
-	teardown := SetUp(t, v3ioConfig)
-	adapter := InsertData(t, v3ioConfig, metricName, data, userLabels)
+func SetUpWithData(t *testing.T, testOpts TestParams) (*V3ioAdapter, func()) {
+	teardown := SetUp(t, testOpts)
+	adapter := InsertData(t, testOpts)
 	return adapter, teardown
 }
 
-func SetUpWithDBConfig(t *testing.T, v3ioConfig *config.V3ioConfig, schema *config.Schema) func() {
+func SetUpWithDBConfig(t *testing.T, schema *config.Schema, testParams TestParams) func() {
+	v3ioConfig := testParams.V3ioConfig()
 	v3ioConfig.TablePath = PrefixTablePath(fmt.Sprintf("%s-%d", t.Name(), time.Now().Nanosecond()))
 	if err := CreateTSDB(v3ioConfig, schema); err != nil {
 		v3ioConfigAsJson, _ := json2.MarshalIndent(v3ioConfig, "", "  ")
@@ -100,15 +158,12 @@ func SetUpWithDBConfig(t *testing.T, v3ioConfig *config.V3ioConfig, schema *conf
 
 	return func() {
 		defer metricReporter.Stop()
-		// Don't delete the TSDB table if the test failed
-		if !t.Failed() {
-			DeleteTSDB(t, v3ioConfig)
-		}
+		tearDown(t, v3ioConfig, testParams)
 	}
 }
 
-func InsertData(t *testing.T, v3ioConfig *config.V3ioConfig, metricName string, data []DataPoint, userLabels utils.Labels) *V3ioAdapter {
-	adapter, err := NewV3ioAdapter(v3ioConfig, nil, nil)
+func InsertData(t *testing.T, testParams TestParams) *V3ioAdapter {
+	adapter, err := NewV3ioAdapter(testParams.V3ioConfig(), nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create a V3IO TSDB adapter. Reason: %s", err)
 	}
@@ -118,19 +173,24 @@ func InsertData(t *testing.T, v3ioConfig *config.V3ioConfig, metricName string, 
 		t.Fatalf("Failed to get an appender. Reason: %s", err)
 	}
 
-	labels := utils.Labels{utils.Label{Name: "__name__", Value: metricName}}
-	labels = append(labels, userLabels...)
+	timeSeries := testParams.TimeSeries()
 
-	ref, err := appender.Add(labels, data[0].Time, data[0].Value)
-	if err != nil {
-		t.Fatalf("Failed to add data to the TSDB appender. Reason: %s", err)
-	}
-	for _, curr := range data[1:] {
-		appender.AddFast(labels, ref, curr.Time, curr.Value)
-	}
+	for _, metric := range timeSeries {
 
-	if _, err := appender.WaitForCompletion(0); err != nil {
-		t.Fatalf("Failed to wait for TSDB append completion. Reason: %s", err)
+		labels := utils.Labels{utils.Label{Name: "__name__", Value: metric.Name}}
+		labels = append(labels, metric.Labels...)
+
+		ref, err := appender.Add(labels, metric.Data[0].Time, metric.Data[0].Value)
+		if err != nil {
+			t.Fatalf("Failed to add data to the TSDB appender. Reason: %s", err)
+		}
+		for _, curr := range metric.Data[1:] {
+			appender.AddFast(labels, ref, curr.Time, curr.Value)
+		}
+
+		if _, err := appender.WaitForCompletion(0); err != nil {
+			t.Fatalf("Failed to wait for TSDB append completion. Reason: %s", err)
+		}
 	}
 
 	return adapter

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -44,59 +44,80 @@ const minuteInMillis = 60 * 1000
 const defaultStepMs = 5 * minuteInMillis // 5 minutes
 
 func TestIngestData(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-
 	testCases := []struct {
-		desc         string
-		metricName   string
-		labels       []utils.Label
-		data         []tsdbtest.DataPoint
-		ignoreReason string
+		desc   string
+		params tsdbtest.TestParams
 	}{
-		{desc: "Should ingest one data point", metricName: "cpu", labels: utils.LabelsFromStrings("testLabel", "balbala"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}}},
-
-		{desc: "Should ingest multiple data points", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 3234.6}}},
-
-		{desc: "Should ingest record with late arrival same chunk", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 - 10, Value: 3234.6}}},
-
-		{desc: "Should ingest record with a dash in the metric name (IG-8585)", metricName: "cool-cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 - 10, Value: 3234.6}}},
+		{desc: "Should ingest one data point",
+			params: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3}},
+					}}},
+			),
+		},
+		{desc: "Should ingest multiple data points",
+			params: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 3234.6}},
+					}}},
+			),
+		},
+		{desc: "Should ingest record with late arrival same chunk",
+			params: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 - 10, Value: 3234.6}},
+					}}},
+			),
+		},
+		{desc: "Should ingest record with a dash in the metric name (IG-8585)",
+			params: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cool-cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 - 10, Value: 3234.6}},
+					}}},
+			),
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			if test.ignoreReason != "" {
-				t.Skip(test.ignoreReason)
+			if test.params.IgnoreReason() != "" {
+				t.Skip(test.params.IgnoreReason())
 			}
-			testIngestDataCase(t, v3ioConfig, test.metricName, test.labels, test.data)
+			testIngestDataCase(t, test.params)
 		})
 	}
 }
 
-func testIngestDataCase(t *testing.T, v3ioConfig *config.V3ioConfig,
-	metricsName string, userLabels []utils.Label, data []tsdbtest.DataPoint) {
-	defer tsdbtest.SetUp(t, v3ioConfig)()
+func testIngestDataCase(t *testing.T, testParams tsdbtest.TestParams) {
+	defer tsdbtest.SetUp(t, testParams)()
 
-	sort.Sort(tsdbtest.DataPointTimeSorter(data))
-	from := data[0].Time
-	to := data[len(data)-1].Time
-
-	adapter, err := NewV3ioAdapter(v3ioConfig, nil, nil)
+	adapter, err := NewV3ioAdapter(testParams.V3ioConfig(), nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create v3io adapter. reason: %s", err)
 	}
@@ -106,35 +127,34 @@ func testIngestDataCase(t *testing.T, v3ioConfig *config.V3ioConfig,
 		t.Fatalf("Failed to get appender. reason: %s", err)
 	}
 
-	labels := utils.Labels{utils.Label{Name: "__name__", Value: metricsName}}
-	labels = append(labels, userLabels...)
+	for _, dp := range testParams.TimeSeries() {
+		sort.Sort(tsdbtest.DataPointTimeSorter(dp.Data))
+		from := dp.Data[0].Time
+		to := dp.Data[len(dp.Data)-1].Time
 
-	ref, err := appender.Add(labels, data[0].Time, data[0].Value)
-	if err != nil {
-		t.Fatalf("Failed to add data to appender. reason: %s", err)
-	}
-	for _, curr := range data[1:] {
-		appender.AddFast(labels, ref, curr.Time, curr.Value)
-	}
+		labels := utils.Labels{utils.Label{Name: "__name__", Value: dp.Name}}
+		labels = append(labels, dp.Labels...)
 
-	if _, err := appender.WaitForCompletion(0); err != nil {
-		t.Fatalf("Failed to wait for appender completion. reason: %s", err)
-	}
+		ref, err := appender.Add(labels, dp.Data[0].Time, dp.Data[0].Value)
+		if err != nil {
+			t.Fatalf("Failed to add data to appender. reason: %s", err)
+		}
+		for _, curr := range dp.Data[1:] {
+			appender.AddFast(labels, ref, curr.Time, curr.Value)
+		}
 
-	tsdbtest.ValidateCountOfSamples(t, adapter, metricsName, len(data), from, to, -1)
+		if _, err := appender.WaitForCompletion(0); err != nil {
+			t.Fatalf("Failed to wait for appender completion. reason: %s", err)
+		}
+
+		tsdbtest.ValidateCountOfSamples(t, adapter, dp.Name, len(dp.Data), from, to, -1)
+	}
 }
 
 func TestQueryData(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-
 	testCases := []struct {
 		desc         string
-		metricName   string
-		labels       []utils.Label
-		data         []tsdbtest.DataPoint
+		testParams   tsdbtest.TestParams
 		filter       string
 		aggregates   string
 		from         int64
@@ -144,19 +164,34 @@ func TestQueryData(t *testing.T) {
 		ignoreReason string
 		expectFail   bool
 	}{
-		{desc: "Should ingest and query one data point", metricName: "cpu",
-			labels:   utils.LabelsFromStrings("testLabel", "balbala"),
-			data:     []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+		{desc: "Should ingest and query one data point",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("testLabel", "balbala"),
+						Data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+					}}},
+			),
 			from:     0,
 			to:       1532940510 + 1,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
-		{desc: "Should ingest and query multiple data points", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510 - 10, Value: 314.3},
-				{Time: 1532940510 - 5, Value: 300.3},
-				{Time: 1532940510, Value: 3234.6}},
+		{desc: "Should ingest and query multiple data points",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510 - 10, Value: 314.3},
+							{Time: 1532940510 - 5, Value: 300.3},
+							{Time: 1532940510, Value: 3234.6}},
+					}}},
+			),
 			from: 0,
 			to:   1532940510 + 1,
 			step: defaultStepMs,
@@ -164,81 +199,142 @@ func TestQueryData(t *testing.T) {
 				{Time: 1532940510 - 5, Value: 300.3},
 				{Time: 1532940510, Value: 3234.6}}}},
 
-		{desc: "Should query with filter on metric name", metricName: "cpu",
-			labels:   utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data:     []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+		{desc: "Should query with filter on metric name",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+					}}},
+			),
 			filter:   "_name=='cpu'",
 			from:     0,
 			to:       1532940510 + 1,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 33.3}}}},
 
-		{desc: "Should query with filter on label name", metricName: "cpu",
-			labels:   utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data:     []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
+		{desc: "Should query with filter on label name",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 31.3}},
+					}}},
+			),
 			filter:   "os=='linux'",
 			from:     0,
 			to:       1532940510 + 1,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 31.3}}}},
 
-		{desc: "Should ingest and query data with '-' in the metric name (IG-8585)", metricName: "cool-cpu",
-			labels:   utils.LabelsFromStrings("testLabel", "balbala"),
-			data:     []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+		{desc: "Should ingest and query data with '-' in the metric name (IG-8585)",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cool-cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3}},
+					}}},
+			),
 			from:     0,
 			to:       1532940510 + 1,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510, Value: 314.3}}}},
 
-		{desc: "Should ingest and query by time", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 3234.6}},
+		{desc: "Should ingest and query by time",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 3234.6}},
+					}}},
+			),
 			from: 1532940510 + 2,
 			to:   1532940510 + 12,
 			step: defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{"": {{Time: 1532940510 + 5, Value: 300.3},
 				{Time: 1532940510 + 10, Value: 3234.6}}}},
 
-		{desc: "Should ingest and query by time with no results", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 3234.6}},
+		{desc: "Should ingest and query by time with no results",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 3234.6}},
+					}}},
+			),
 			from:     1532940510 + 1,
 			to:       1532940510 + 4,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{}},
 
-		{desc: "Should ingest and query an aggregate", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 300.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 100.4}},
+		{desc: "Should ingest and query an aggregate",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 300.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 100.4}},
+					}}},
+			),
 			from:       1532940510,
 			to:         1532940510 + 11,
 			step:       defaultStepMs,
 			aggregates: "sum",
 			expected:   map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940510, Value: 701.0}}}},
 
-		{desc: "Should ingest and query an aggregate with interval greater than step size", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 300.3},
-				{Time: 1532940510 + 60, Value: 300.3},
-				{Time: 1532940510 + 2*60, Value: 100.4},
-				{Time: 1532940510 + 5*60, Value: 200.0}},
+		{desc: "Should ingest and query an aggregate with interval greater than step size",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 300.3},
+							{Time: 1532940510 + 60, Value: 300.3},
+							{Time: 1532940510 + 2*60, Value: 100.4},
+							{Time: 1532940510 + 5*60, Value: 200.0}},
+					}}},
+			),
 			from:       1532940510,
 			to:         1532940510 + 6*60,
 			step:       defaultStepMs,
 			aggregates: "sum",
 			expected:   map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940510, Value: 901.0}}}},
 
-		{desc: "Should ingest and query multiple aggregates", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 300.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 100.4}},
+		{desc: "Should ingest and query multiple aggregates",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 300.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 100.4}},
+					}}},
+			),
 			from:       1532940510,
 			to:         1532940510 + 11,
 			step:       defaultStepMs,
@@ -246,31 +342,54 @@ func TestQueryData(t *testing.T) {
 			expected: map[string][]tsdbtest.DataPoint{"sum": {{Time: 1532940510, Value: 701.0}},
 				"count": {{Time: 1532940510, Value: 3}}}},
 
-		{desc: "Should fail on query with illegal time (switch from and to)", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 314.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 3234.6}},
+		{desc: "Should fail on query with illegal time (switch from and to)",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 314.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 3234.6}},
+					}}},
+			),
 			from:       1532940510 + 1,
 			to:         0,
 			step:       defaultStepMs,
 			expectFail: true,
 		},
 
-		{desc: "Should query with filter on not existing metric name", metricName: "cpu",
-			labels:   utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data:     []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+		{desc: "Should query with filter on not existing metric name",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data:   []tsdbtest.DataPoint{{Time: 1532940510, Value: 33.3}},
+					}}},
+			),
 			filter:   "_name=='hahaha'",
 			from:     0,
 			to:       1532940510 + 1,
 			step:     defaultStepMs,
 			expected: map[string][]tsdbtest.DataPoint{}},
 
-		{desc: "Should ingest and query aggregates with empty bucket", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1537972278402, Value: 300.3},
-				{Time: 1537972278402 + 8*minuteInMillis, Value: 300.3},
-				{Time: 1537972278402 + 9*minuteInMillis, Value: 100.4}},
+		{desc: "Should ingest and query aggregates with empty bucket",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1537972278402, Value: 300.3},
+							{Time: 1537972278402 + 8*minuteInMillis, Value: 300.3},
+							{Time: 1537972278402 + 9*minuteInMillis, Value: 100.4}},
+					}}},
+			),
 			from:       1537972278402 - 5*minuteInMillis,
 			to:         1537972278402 + 10*minuteInMillis,
 			step:       defaultStepMs,
@@ -279,11 +398,19 @@ func TestQueryData(t *testing.T) {
 				"count": {{Time: 1537972278402, Value: 1},
 					{Time: 1537972578402, Value: 2}}}},
 
-		{desc: "Should ingest and query aggregates with few empty buckets in a row", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1537972278402, Value: 300.3},
-				{Time: 1537972278402 + 16*minuteInMillis, Value: 300.3},
-				{Time: 1537972278402 + 17*minuteInMillis, Value: 100.4}},
+		{desc: "Should ingest and query aggregates with few empty buckets in a row",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1537972278402, Value: 300.3},
+							{Time: 1537972278402 + 16*minuteInMillis, Value: 300.3},
+							{Time: 1537972278402 + 17*minuteInMillis, Value: 100.4}},
+					}}},
+			),
 			from:       1537972278402 - 5*minuteInMillis,
 			to:         1537972278402 + 18*minuteInMillis,
 			step:       defaultStepMs,
@@ -292,11 +419,19 @@ func TestQueryData(t *testing.T) {
 				"count": {{Time: 1537972158402, Value: 1},
 					{Time: 1537973058402, Value: 2}}}},
 
-		{desc: "Should ingest and query server-side aggregates", metricName: "cpu",
-			labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
-			data: []tsdbtest.DataPoint{{Time: 1532940510, Value: 300.3},
-				{Time: 1532940510 + 5, Value: 300.3},
-				{Time: 1532940510 + 10, Value: 100.4}},
+		{desc: "Should ingest and query server-side aggregates",
+			testParams: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cpu",
+						Labels: utils.LabelsFromStrings("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 1532940510, Value: 300.3},
+							{Time: 1532940510 + 5, Value: 300.3},
+							{Time: 1532940510 + 10, Value: 100.4}},
+					}}},
+			),
 			from:       1532940510,
 			to:         1532940510 + 11,
 			step:       60 * minuteInMillis,
@@ -314,16 +449,15 @@ func TestQueryData(t *testing.T) {
 			if test.ignoreReason != "" {
 				t.Skip(test.ignoreReason)
 			}
-			testQueryDataCase(t, v3ioConfig, test.metricName, test.labels,
-				test.data, test.filter, test.aggregates, test.from, test.to, test.step, test.expected, test.expectFail)
+			testQueryDataCase(t, test.testParams, test.filter, test.aggregates, test.from, test.to, test.step, test.expected, test.expectFail)
 		})
 	}
 }
 
-func testQueryDataCase(test *testing.T, v3ioConfig *config.V3ioConfig,
-	metricsName string, userLabels []utils.Label, data []tsdbtest.DataPoint, filter string, agg string,
+func testQueryDataCase(test *testing.T, testParams tsdbtest.TestParams, filter string, queryAggregates string,
 	from int64, to int64, step int64, expected map[string][]tsdbtest.DataPoint, expectFail bool) {
-	adapter, teardown := tsdbtest.SetUpWithData(test, v3ioConfig, metricsName, data, userLabels)
+
+	adapter, teardown := tsdbtest.SetUpWithData(test, testParams)
 	defer teardown()
 
 	qry, err := adapter.Querier(nil, from, to)
@@ -335,36 +469,38 @@ func testQueryDataCase(test *testing.T, v3ioConfig *config.V3ioConfig,
 		}
 	}
 
-	set, err := qry.Select(metricsName, agg, step, filter)
-	if err != nil {
-		test.Fatalf("Failed to run Select. reason: %v", err)
-	}
+	for _, metric := range testParams.TimeSeries() {
+		set, err := qry.Select(metric.Name, queryAggregates, step, filter)
+		if err != nil {
+			test.Fatalf("Failed to run Select. reason: %v", err)
+		}
 
-	var counter int
-	for counter = 0; set.Next(); counter++ {
+		var counter int
+		for counter = 0; set.Next(); counter++ {
+			if set.Err() != nil {
+				test.Fatalf("Failed to query metric. reason: %v", set.Err())
+			}
+
+			series := set.At()
+			currentAggregate := series.Labels().Get(aggregate.AggregateLabel)
+			iter := series.Iterator()
+			if iter.Err() != nil {
+				test.Fatalf("Failed to query data series. reason: %v", iter.Err())
+			}
+
+			actual, err := iteratorToSlice(iter)
+			if err != nil {
+				test.Fatal(err)
+			}
+			assert.ElementsMatch(test, expected[currentAggregate], actual, "Check failed for aggregate='%s'. Query aggregates: %s", currentAggregate, queryAggregates)
+		}
+
 		if set.Err() != nil {
 			test.Fatalf("Failed to query metric. reason: %v", set.Err())
 		}
-
-		series := set.At()
-		agg := series.Labels().Get(aggregate.AggregateLabel)
-		iter := series.Iterator()
-		if iter.Err() != nil {
-			test.Fatalf("Failed to query data series. reason: %v", iter.Err())
+		if counter == 0 && len(expected) > 0 {
+			test.Fatalf("No data was received")
 		}
-
-		actual, err := iteratorToSlice(iter)
-		if err != nil {
-			test.Fatal(err)
-		}
-		assert.ElementsMatch(test, expected[agg], actual)
-	}
-
-	if set.Err() != nil {
-		test.Fatalf("Failed to query metric. reason: %v", set.Err())
-	}
-	if counter == 0 && len(expected) > 0 {
-		test.Fatalf("No data was received")
 	}
 }
 
@@ -442,7 +578,13 @@ func testQueryDataOverlappingWindowCase(test *testing.T, v3ioConfig *config.V3io
 	metricsName string, userLabels []utils.Label, data []tsdbtest.DataPoint, filter string,
 	windows []int, agg string,
 	from int64, to int64, expected map[string][]tsdbtest.DataPoint) {
-	adapter, teardown := tsdbtest.SetUpWithData(test, v3ioConfig, metricsName, data, userLabels)
+
+	testParams := tsdbtest.NewTestParams(test,
+		tsdbtest.TestOption{Key: tsdbtest.OptV3ioConfig, Value: v3ioConfig},
+		tsdbtest.TestOption{Key: tsdbtest.OptTimeSeries, Value: tsdbtest.TimeSeries{tsdbtest.Metric{Name: metricsName, Data: data, Labels: userLabels}}},
+	)
+
+	adapter, teardown := tsdbtest.SetUpWithData(test, testParams)
 	defer teardown()
 
 	var step int64 = 3600
@@ -510,7 +652,12 @@ func TestIgnoreNaNWhenSeekingAggSeries(t *testing.T) {
 			{baseTime + step, 100.4},
 			{baseTime + 2*step, 200}}}
 
-	adapter, teardown := tsdbtest.SetUpWithData(t, v3ioConfig, metricsName, data, userLabels)
+	testParams := tsdbtest.NewTestParams(t,
+		tsdbtest.TestOption{Key: tsdbtest.OptV3ioConfig, Value: v3ioConfig},
+		tsdbtest.TestOption{Key: tsdbtest.OptTimeSeries, Value: tsdbtest.TimeSeries{tsdbtest.Metric{Name: metricsName, Data: data, Labels: userLabels}}},
+	)
+
+	adapter, teardown := tsdbtest.SetUpWithData(t, testParams)
 	defer teardown()
 
 	qry, err := adapter.Querier(nil, from, to)
@@ -564,11 +711,6 @@ func TestIgnoreNaNWhenSeekingAggSeries(t *testing.T) {
 }
 
 func TestCreateTSDB(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-
 	testCases := []struct {
 		desc         string
 		conf         *config.Schema
@@ -579,20 +721,22 @@ func TestCreateTSDB(t *testing.T) {
 		{desc: "Should create TSDB with wildcard aggregations", conf: testutils.CreateSchema(t, "*")},
 	}
 
+	testParams := tsdbtest.NewTestParams(t)
+
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			if test.ignoreReason != "" {
 				t.Skip(test.ignoreReason)
 			}
-			testCreateTSDBcase(t, v3ioConfig, test.conf)
+			testCreateTSDBcase(t, test.conf, testParams)
 		})
 	}
 }
 
-func testCreateTSDBcase(t *testing.T, v3ioConfig *config.V3ioConfig, dbConfig *config.Schema) {
-	defer tsdbtest.SetUpWithDBConfig(t, v3ioConfig, dbConfig)()
+func testCreateTSDBcase(t *testing.T, dbConfig *config.Schema, testParams tsdbtest.TestParams) {
+	defer tsdbtest.SetUpWithDBConfig(t, dbConfig, testParams)()
 
-	adapter, err := NewV3ioAdapter(v3ioConfig, nil, nil)
+	adapter, err := NewV3ioAdapter(testParams.V3ioConfig(), nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create adapter. reason: %s", err)
 	}
@@ -637,11 +781,6 @@ func TestDeleteTSDB(t *testing.T) {
 }
 
 func TestDeleteTable(t *testing.T) {
-	v3ioConfig, err := tsdbtest.LoadV3ioConfig()
-	if err != nil {
-		t.Fatalf("unable to load configuration. Error: %v", err)
-	}
-
 	ta, _ := time.Parse(time.RFC3339, "2018-10-03T05:00:00Z")
 	t1 := ta.Unix() * 1000
 	tb, _ := time.Parse(time.RFC3339, "2018-10-07T05:00:00Z")
@@ -731,20 +870,31 @@ func TestDeleteTable(t *testing.T) {
 			if test.ignoreReason != "" {
 				t.Skip(test.ignoreReason)
 			}
-			testDeleteTSDBCase(t, v3ioConfig, "metricToDelete", utils.LabelsFromStrings("os", "linux"),
-				test.data, test.deleteFrom, test.deleteTo, test.ignoreErrors, test.deleteAll, test.expected)
+			testDeleteTSDBCase(t,
+				tsdbtest.NewTestParams(t,
+					tsdbtest.TestOption{
+						Key:   tsdbtest.OptDropTableOnTearDown,
+						Value: !test.deleteAll},
+					tsdbtest.TestOption{
+						Key: tsdbtest.OptTimeSeries,
+						Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+							Name:   "metricToDelete",
+							Labels: utils.LabelsFromStrings("os", "linux"),
+							Data:   test.data,
+						}}},
+				),
+				test.deleteFrom, test.deleteTo, test.ignoreErrors, test.deleteAll, test.expected)
 		})
 	}
 }
 
-func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsName string, userLabels []utils.Label,
-	data []tsdbtest.DataPoint, deleteFrom int64, deleteTo int64, ignoreErrors bool, deleteAll bool,
+func testDeleteTSDBCase(test *testing.T, testParams tsdbtest.TestParams, deleteFrom int64, deleteTo int64, ignoreErrors bool, deleteAll bool,
 	expected []tsdbtest.DataPoint) {
 
-	adapter, teardown := tsdbtest.SetUpWithData(test, v3ioConfig, metricsName, data, userLabels)
+	adapter, teardown := tsdbtest.SetUpWithData(test, testParams)
 	defer teardown()
 
-	pm, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, v3ioConfig)
+	pm, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, testParams.V3ioConfig())
 	if err != nil {
 		test.Fatalf("Failed to create new partition manager. reason: %s", err)
 	}
@@ -758,23 +908,17 @@ func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsN
 		test.Fatalf("Failed to delete DB. reason: %s", err)
 	}
 
-	if deleteAll {
-		_, err := NewV3ioAdapter(v3ioConfig, nil, nil)
-		if err == nil {
-			test.Fatalf("Table was deleted - failure to create adapter is expected...")
-		}
-		test.Skip("skipping tearDown since table is completely deleted")
-	} else {
-		pm1, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, v3ioConfig)
-		remainingParts := pm1.PartsForRange(0, math.MaxInt64, false)
-		assert.Equal(test, len(remainingParts), initialNumberOfPartitions-len(partitionsToDelete))
+	pm1, err := partmgr.NewPartitionMngr(adapter.GetSchema(), nil, testParams.V3ioConfig())
+	remainingParts := pm1.PartsForRange(0, math.MaxInt64, false)
+	assert.Equal(test, len(remainingParts), initialNumberOfPartitions-len(partitionsToDelete))
 
-		qry, err := adapter.Querier(nil, 0, math.MaxInt64)
-		if err != nil {
-			test.Fatalf("Failed to create Querier. reason: %v", err)
-		}
+	qry, err := adapter.Querier(nil, 0, math.MaxInt64)
+	if err != nil {
+		test.Fatalf("Failed to create Querier. reason: %v", err)
+	}
 
-		set, err := qry.Select(metricsName, "", 0, "")
+	for _, metric := range testParams.TimeSeries() {
+		set, err := qry.Select(metric.Name, "", 0, "")
 		if err != nil {
 			test.Fatalf("Failed to run Select. reason: %v", err)
 		}
@@ -801,7 +945,6 @@ func testDeleteTSDBCase(test *testing.T, v3ioConfig *config.V3ioConfig, metricsN
 		} else {
 			test.Fatalf("Result series is empty while expected result set is not!")
 		}
-
 	}
 }
 


### PR DESCRIPTION
- Use tsdbtest.LoadV3ioConfig() by default to initialize v3io config for integration tests
- Pass `TestParams` as an argument to the tear down function, so you can change tear down behavior of a test
- Following options supported out of the box, other could be added on demand:
  - [x] OptDropTableOnTearDown
  - [x] OptIgnoreReason
  - [x] OptTimeSeries
  - [x] OptV3ioConfig