### PR TITLE
fix duplicate partitions in schema bug & query with maximum range bug

### DIFF
--- a/pkg/partmgr/partmgr.go
+++ b/pkg/partmgr/partmgr.go
@@ -136,7 +136,7 @@ func (p *PartitionManager) TimeToPart(t int64) (*DBPartition, error) {
 		} else {
 			// Iterate backwards; ignore the last element as it's the head partition
 			for i := len(p.partitions) - 2; i >= 0; i-- {
-				if t > p.partitions[i].startTime {
+				if t >= p.partitions[i].startTime {
 					return p.partitions[i], nil
 				}
 			}

--- a/pkg/pquerier/querier.go
+++ b/pkg/pquerier/querier.go
@@ -116,7 +116,7 @@ func (q *V3ioQuerier) baseSelectQry(params *SelectParams, showAggregateLabel boo
 	}
 
 	selectContext := selectQueryContext{
-		mint: params.From, maxt: params.To, step: params.Step, filter: params.Filter,
+		step: params.Step, filter: params.Filter,
 		container: q.container, logger: q.logger, workers: q.cfg.QryWorkers,
 		disableAllAggr: params.disableAllAggr, disableClientAggr: params.disableClientAggr,
 		showAggregateLabel: showAggregateLabel,
@@ -134,6 +134,14 @@ func (q *V3ioQuerier) baseSelectQry(params *SelectParams, showAggregateLabel boo
 		parts := q.partitionMngr.PartsForRange(params.From, params.To, true)
 		if len(parts) == 0 {
 			return
+		}
+
+		minExistingTime, maxExistingTime := parts[0].GetStartTime(), parts[len(parts)-1].GetEndTime()
+		if params.From < minExistingTime {
+			params.From = minExistingTime
+		}
+		if params.To > maxExistingTime {
+			params.To = maxExistingTime
 		}
 
 		iter, err = selectContext.start(parts, params)

--- a/pkg/pquerier/select.go
+++ b/pkg/pquerier/select.go
@@ -51,7 +51,7 @@ type selectQueryContext struct {
 
 func (queryCtx *selectQueryContext) start(parts []*partmgr.DBPartition, params *SelectParams) (*frameIterator, error) {
 	queryCtx.dataFrames = make(map[uint64]*dataFrame)
-
+	queryCtx.mint, queryCtx.maxt = params.From, params.To
 	// If step isn't passed (e.g., when using the console), the step is the
 	// difference between the end (maxt) and start (mint) times (e.g., 5 minutes)
 	if params.Functions != "" && queryCtx.step == 0 {


### PR DESCRIPTION
* there is was a bug that sometimes the same partition will be written to the schema file multiple times in different order. for example let's say the partition interval is 1 day. you might have the following scenario: partitions start time in schema: yesterday, today, yesterday, yesterday. 

* when querying for aggregates with max range (0 to maxInt) you'll get panic