### PR TITLE
fix showing incorrect results when querying DF

### DIFF
--- a/pkg/pquerier/frames.go
+++ b/pkg/pquerier/frames.go
@@ -355,10 +355,13 @@ func (d *dataFrame) rawSeriesToColumns() {
 	nextTime := int64(math.MaxInt64)
 
 	for _, rawSeries := range d.rawColumns {
-		rawSeries.Iterator().Next()
-		t, _ := rawSeries.Iterator().At()
-		if t < nextTime {
-			nextTime = t
+		if rawSeries.Iterator().Next() {
+			t, _ := rawSeries.Iterator().At()
+			if t < nextTime {
+				nextTime = t
+			}
+		} else {
+			nonExhaustedIterators--
 		}
 	}
 

--- a/pkg/pquerier/query_integration_test.go
+++ b/pkg/pquerier/query_integration_test.go
@@ -2003,6 +2003,136 @@ func (suite *testQuerySuite) TestAggregatesWithZeroStepSelectDataframe() {
 	assert.Equal(suite.T(), 1, seriesCount, "series count didn't match expected")
 }
 
+func (suite *testQuerySuite) TestEmptyRawDataSelectDataframe() {
+	adapter, err := tsdb.NewV3ioAdapter(suite.v3ioConfig, nil, nil)
+	if err != nil {
+		suite.T().Fatalf("failed to create v3io adapter. reason: %s", err)
+	}
+
+	labels1 := utils.LabelsFromStringList("os", "linux")
+	numberOfEvents := 10
+	eventsInterval := 60 * 1000
+	baseTime := tsdbtest.NanosToMillis(time.Now().UnixNano()) - int64(numberOfEvents*eventsInterval)
+
+	ingestedData := []tsdbtest.DataPoint{{baseTime, 10},
+		{int64(baseTime + tsdbtest.MinuteInMillis), 20},
+		{baseTime + 2*tsdbtest.MinuteInMillis, 30},
+		{baseTime + 3*tsdbtest.MinuteInMillis, 40}}
+	testParams := tsdbtest.NewTestParams(suite.T(),
+		tsdbtest.TestOption{
+			Key: tsdbtest.OptTimeSeries,
+			Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+				Name:   "cpu",
+				Labels: labels1,
+				Data:   ingestedData},
+			}})
+	tsdbtest.InsertData(suite.T(), testParams)
+
+	querierV2, err := adapter.QuerierV2()
+	if err != nil {
+		suite.T().Fatalf("Failed to create querier v2, err: %v", err)
+	}
+
+	params := &pquerier.SelectParams{Name: "cpu", From: baseTime - 10*tsdbtest.MinuteInMillis, To: baseTime - 1*tsdbtest.MinuteInMillis}
+	set, err := querierV2.SelectDataFrame(params)
+	if err != nil {
+		suite.T().Fatalf("Failed to exeute query, err: %v", err)
+	}
+
+	var seriesCount int
+	for set.NextFrame() {
+		seriesCount++
+		frame := set.GetFrame()
+
+		assert.Equal(suite.T(), 0, frame.Index().Len())
+
+		for _, col := range frame.Columns() {
+			assert.Equal(suite.T(), 0, col.Len())
+		}
+	}
+
+	assert.Equal(suite.T(), 1, seriesCount, "series count didn't match expected")
+}
+
+func (suite *testQuerySuite) Test2Series1EmptySelectDataframe() {
+	adapter, err := tsdb.NewV3ioAdapter(suite.v3ioConfig, nil, nil)
+	if err != nil {
+		suite.T().Fatalf("failed to create v3io adapter. reason: %s", err)
+	}
+
+	labels1 := utils.LabelsFromStringList("os", "linux")
+	numberOfEvents := 10
+	eventsInterval := 60 * 1000
+	baseTime := tsdbtest.NanosToMillis(time.Now().UnixNano()) - int64(numberOfEvents*eventsInterval)
+
+	ingestedData := []tsdbtest.DataPoint{{baseTime, 10},
+		{int64(baseTime + tsdbtest.MinuteInMillis), 20},
+		{baseTime + 2*tsdbtest.MinuteInMillis, 30},
+		{baseTime + 3*tsdbtest.MinuteInMillis, 40}}
+	testParams := tsdbtest.NewTestParams(suite.T(),
+		tsdbtest.TestOption{
+			Key: tsdbtest.OptTimeSeries,
+			Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+				Name:   "cpu",
+				Labels: labels1,
+				Data:   ingestedData},
+				tsdbtest.Metric{
+					Name:   "diskio",
+					Labels: labels1,
+					Data:   []tsdbtest.DataPoint{{baseTime + 10*tsdbtest.MinuteInMillis, 10}}},
+			}})
+	tsdbtest.InsertData(suite.T(), testParams)
+
+	expected := map[string][]tsdbtest.DataPoint{"cpu": ingestedData,
+		"diskio": {{baseTime, math.NaN()},
+			{int64(baseTime + tsdbtest.MinuteInMillis), math.NaN()},
+			{baseTime + 2*tsdbtest.MinuteInMillis, math.NaN()},
+			{baseTime + 3*tsdbtest.MinuteInMillis, math.NaN()}},
+	}
+
+	querierV2, err := adapter.QuerierV2()
+	if err != nil {
+		suite.T().Fatalf("Failed to create querier v2, err: %v", err)
+	}
+
+	params, _, _ := pquerier.ParseQuery("select cpu,diskio")
+	params.From = baseTime
+	params.To = baseTime + 4*tsdbtest.MinuteInMillis
+
+	set, err := querierV2.SelectDataFrame(params)
+	if err != nil {
+		suite.T().Fatalf("Failed to exeute query, err: %v", err)
+	}
+
+	var seriesCount int
+	for set.NextFrame() {
+		seriesCount++
+		frame := set.GetFrame()
+
+		assert.Equal(suite.T(), len(ingestedData), frame.Index().Len())
+		for i := 0; i < frame.Index().Len(); i++ {
+			t, err := frame.Index().TimeAt(i)
+			assert.NoError(suite.T(), err)
+			assert.Equal(suite.T(), ingestedData[i].Time, t.UnixNano()/int64(time.Millisecond))
+		}
+
+		for _, col := range frame.Columns() {
+			assert.Equal(suite.T(), len(ingestedData), col.Len())
+			for i := 0; i < col.Len(); i++ {
+				currentExpected := expected[col.Name()][i].Value
+				f, err := col.FloatAt(i)
+				assert.NoError(suite.T(), err)
+
+				if !(math.IsNaN(currentExpected) && math.IsNaN(f)) {
+					assert.Equal(suite.T(), currentExpected, f)
+				}
+			}
+		}
+	}
+
+	assert.Equal(suite.T(), 1, seriesCount, "series count didn't match expected")
+}
+
 func (suite *testQuerySuite) toMillis(date string) int64 {
 	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {


### PR DESCRIPTION
**bug description:**
if you query for DF with a time range that should return no data there is still one line in the result. (first item in the chunk)