### PR TITLE
Output formatting changes

### DIFF
--- a/pkg/formatter/formatters.go
+++ b/pkg/formatter/formatters.go
@@ -4,6 +4,8 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/v3io/v3io-tsdb/pkg/chunkenc"
@@ -45,6 +47,13 @@ func (f textFormatter) Write(out io.Writer, set utils.SeriesSet) error {
 	return nil
 }
 
+func (f textFormatter) timeString(t int64) string {
+	if f.cfg.TimeFormat == "" {
+		return strconv.Itoa(int(t))
+	}
+	return time.Unix(t/1000, 0).Format(f.cfg.TimeFormat)
+}
+
 type csvFormatter struct {
 	baseFormatter
 }
@@ -61,7 +70,7 @@ func (f csvFormatter) Write(out io.Writer, set utils.SeriesSet) error {
 		for iter.Next() {
 
 			t, v := iter.At()
-			writer.Write([]string{name, labelStr, fmt.Sprintf("%.6f", v), f.timeString(t)})
+			_ = writer.Write([]string{name, labelStr, fmt.Sprintf("%.6f", v), strconv.FormatInt(t, 10)})
 		}
 
 		if iter.Err() != nil {

--- a/pkg/formatter/type.go
+++ b/pkg/formatter/type.go
@@ -3,7 +3,6 @@ package formatter
 import (
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 
@@ -43,16 +42,9 @@ type baseFormatter struct {
 	cfg *FormatterConfig
 }
 
-func (f baseFormatter) timeString(t int64) string {
-	if f.cfg.TimeFormat == "" {
-		return strconv.Itoa(int(t))
-	}
-	return time.Unix(t/1000, 0).UTC().Format(f.cfg.TimeFormat)
-}
-
 func labelsToStr(labels utils.Labels) (string, string) {
 	name := ""
-	lbls := []string{}
+	var lbls []string
 	for _, lbl := range labels {
 		if lbl.Name == "__name__" {
 			name = lbl.Value


### PR DESCRIPTION
* CSV output time is now in millis. E.g.:
```
close,"market=us,stock_name=APPL",13.000000,1551961947000
```

* Human readable output is now in local time. E.g.:
```
Name: close  Labels: market=us,stock_name=APPL
  2019-03-07T14:32:27+02:00  v=13.00
```
