### PR TITLE
Explicitly request client aggr

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,6 +164,8 @@ type V3ioConfig struct {
 	BuildInfo *BuildInfo `json:"buildInfo,omitempty"`
 	// Override nginx bug
 	DisableNginxMitigation bool `json:"disableNginxMitigation,omitempty"`
+	// explicitly always use client aggregation
+	UsePreciseAggregations bool `json:"usePreciseAggregations,omitempty"`
 }
 
 type MetricsReporterConfig struct {

--- a/pkg/pquerier/querier.go
+++ b/pkg/pquerier/querier.go
@@ -49,6 +49,7 @@ type SelectParams struct {
 
 	disableAllAggr    bool
 	disableClientAggr bool
+	useOnlyClientAggr bool
 }
 
 func (s *SelectParams) getRequestedColumns() []RequestedColumn {
@@ -75,7 +76,7 @@ func (q *V3ioQuerier) SelectProm(params *SelectParams, noAggr bool) (utils.Serie
 
 	params.disableClientAggr = true
 	params.disableAllAggr = noAggr
-
+	params.useOnlyClientAggr = q.cfg.UsePreciseAggregations
 	iter, err := q.baseSelectQry(params, false)
 	if err != nil || iter == nil {
 		return utils.NullSeriesSet{}, err
@@ -88,6 +89,7 @@ func (q *V3ioQuerier) SelectProm(params *SelectParams, noAggr bool) (utils.Serie
 func (q *V3ioQuerier) Select(params *SelectParams) (utils.SeriesSet, error) {
 	params.disableAllAggr = false
 	params.disableClientAggr = q.cfg.DisableClientAggr
+	params.useOnlyClientAggr = q.cfg.UsePreciseAggregations
 	iter, err := q.baseSelectQry(params, true)
 	if err != nil || iter == nil {
 		return utils.NullSeriesSet{}, err
@@ -99,6 +101,7 @@ func (q *V3ioQuerier) Select(params *SelectParams) (utils.SeriesSet, error) {
 func (q *V3ioQuerier) SelectDataFrame(params *SelectParams) (FrameSet, error) {
 	params.disableAllAggr = false
 	params.disableClientAggr = q.cfg.DisableClientAggr
+	params.useOnlyClientAggr = q.cfg.UsePreciseAggregations
 	iter, err := q.baseSelectQry(params, true)
 	if err != nil || iter == nil {
 		return nullFrameSet{}, err

--- a/pkg/pquerier/query_integration_test.go
+++ b/pkg/pquerier/query_integration_test.go
@@ -3290,9 +3290,8 @@ func (suite *testQuerySuite) TestUsePreciseAggregationsConfig() {
 	suite.v3ioConfig.UsePreciseAggregations = true
 	defer func() { suite.v3ioConfig.UsePreciseAggregations = false }()
 	adapter, err := tsdb.NewV3ioAdapter(suite.v3ioConfig, nil, nil)
-	if err != nil {
-		suite.T().Fatalf("failed to create v3io adapter. reason: %s", err)
-	}
+	suite.NoError(err, "failed to create v3io adapter.")
+
 	labels1 := utils.LabelsFromStringList("os", "linux")
 	numberOfEvents := 10
 	eventsInterval := 60 * 1000
@@ -3316,15 +3315,11 @@ func (suite *testQuerySuite) TestUsePreciseAggregationsConfig() {
 		"max": {{Time: suite.basicQueryTime, Value: 40}}}
 
 	querierV2, err := adapter.QuerierV2()
-	if err != nil {
-		suite.T().Fatalf("Failed to create querier v2, err: %v", err)
-	}
+	suite.NoError(err, "failed to create querier v2.")
 
 	params := &pquerier.SelectParams{Name: "cpu", Functions: "sum,max,min", Step: 1 * 60 * 60 * 1000, From: suite.basicQueryTime, To: suite.basicQueryTime + int64(numberOfEvents*eventsInterval)}
 	set, err := querierV2.Select(params)
-	if err != nil {
-		suite.T().Fatalf("Failed to exeute query, err: %v", err)
-	}
+	suite.NoError(err, "failed to exeute query,")
 
 	var seriesCount int
 	for set.Next() {
@@ -3337,10 +3332,10 @@ func (suite *testQuerySuite) TestUsePreciseAggregationsConfig() {
 			suite.T().Fatal(err)
 		}
 
-		assert.Equal(suite.T(), expected[agg], data, "queried data does not match expected")
+		suite.Require().Equal(expected[agg], data, "queried data does not match expected")
 	}
 
-	assert.Equal(suite.T(), 3, seriesCount, "series count didn't match expected")
+	suite.Require().Equal(3, seriesCount, "series count didn't match expected")
 }
 
 func (suite *testQuerySuite) toMillis(date string) int64 {

--- a/pkg/pquerier/select.go
+++ b/pkg/pquerier/select.go
@@ -173,7 +173,7 @@ func (queryCtx *selectQueryContext) queryPartition(partition *partmgr.DBPartitio
 			// Cross series aggregations cannot use server side aggregates.
 			newQuery.useServerSideAggregates = aggregationParams.CanAggregate(partition.AggrType()) &&
 				!queryCtx.isCrossSeriesAggregate &&
-				!queryCtx.queryParams.useOnlyClientAggr
+				!queryCtx.queryParams.UseOnlyClientAggr
 			if newQuery.useServerSideAggregates || !queryCtx.queryParams.disableClientAggr {
 				newQuery.aggregationParams = aggregationParams
 			}

--- a/pkg/pquerier/select.go
+++ b/pkg/pquerier/select.go
@@ -171,7 +171,9 @@ func (queryCtx *selectQueryContext) queryPartition(partition *partmgr.DBPartitio
 		newQuery := &partQuery{mint: mint, maxt: maxt, partition: partition, step: queryCtx.queryParams.Step}
 		if aggregationParams != nil {
 			// Cross series aggregations cannot use server side aggregates.
-			newQuery.useServerSideAggregates = aggregationParams.CanAggregate(partition.AggrType()) && !queryCtx.isCrossSeriesAggregate
+			newQuery.useServerSideAggregates = aggregationParams.CanAggregate(partition.AggrType()) &&
+				!queryCtx.isCrossSeriesAggregate &&
+				!queryCtx.queryParams.useOnlyClientAggr
 			if newQuery.useServerSideAggregates || !queryCtx.queryParams.disableClientAggr {
 				newQuery.aggregationParams = aggregationParams
 			}

--- a/pkg/pquerier/types.go
+++ b/pkg/pquerier/types.go
@@ -27,11 +27,11 @@ func (q *qryResults) IsDownsample() bool {
 }
 
 func (q *qryResults) IsServerAggregates() bool {
-	return q.query.aggregationParams != nil && q.query.aggregationParams.CanAggregate(q.query.partition.AggrType())
+	return q.query.aggregationParams != nil && q.query.useServerSideAggregates
 }
 
 func (q *qryResults) IsClientAggregates() bool {
-	return q.query.aggregationParams != nil && !q.query.aggregationParams.CanAggregate(q.query.partition.AggrType())
+	return q.query.aggregationParams != nil && !q.query.useServerSideAggregates
 }
 
 type RequestedColumn struct {

--- a/pkg/tsdbctl/query.go
+++ b/pkg/tsdbctl/query.go
@@ -115,7 +115,7 @@ Arguments:
 	cmd.Flags().StringVar(&commandeer.groupBy, "groupBy", "",
 		"Comma separated list of labels to group the result by")
 	cmd.Flags().BoolVar(&commandeer.usePreciseAggregations, "use-precise-aggregations", false,
-		"Ignore server aggregations optimizations for more accurate results.")
+		"Disable server aggregation optimizations for more accurate results.")
 
 	cmd.Flags().BoolVarP(&commandeer.oldQuerier, "oldQuerier", "q", false, "use old querier")
 	cmd.Flags().Lookup("oldQuerier").Hidden = true


### PR DESCRIPTION
add an option for the user to explicitly request client side aggregations.
Pros: more accurate than server side
Cons: might worsen performance