### PR TITLE
TSDB 112 + TSDB-113

### DIFF
--- a/pkg/pquerier/sql_parser.go
+++ b/pkg/pquerier/sql_parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/v3io/v3io-tsdb/pkg/utils"
 	"github.com/xwb1989/sqlparser"
 )
@@ -119,7 +120,7 @@ func parseFuncExpr(expr *sqlparser.FuncExpr, destCol *RequestedColumn) error {
 		}
 
 		if destCol.Metric == "" && destCol.Alias != "" {
-			return fmt.Errorf("cannot alias a wildcard")
+			return errors.New("cannot alias a wildcard")
 		}
 	}
 
@@ -159,7 +160,7 @@ func validateColumnNames(params *SelectParams) error {
 	for _, column := range params.RequestedColumns {
 		columnName := column.GetColumnName()
 		if names[columnName] {
-			return fmt.Errorf("column name '%v' apears more than once in select query", columnName)
+			return fmt.Errorf("column name '%v' appears more than once in select query", columnName)
 		}
 		names[columnName] = true
 		requestedMetrics[column.Metric] = true

--- a/pkg/pquerier/sql_parser.go
+++ b/pkg/pquerier/sql_parser.go
@@ -166,7 +166,7 @@ func validateColumnNames(params *SelectParams) error {
 	}
 
 	for _, column := range params.RequestedColumns {
-		if requestedMetrics[column.Alias] {
+		if column.Alias != "" && requestedMetrics[column.Alias] {
 			return fmt.Errorf("cannot use a metric name as an alias, alias: %v", column.Alias)
 		}
 	}

--- a/pkg/pquerier/sql_parser_test.go
+++ b/pkg/pquerier/sql_parser_test.go
@@ -76,3 +76,21 @@ func TestParseQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestNegativeParseQuery(t *testing.T) {
+	testCases := []struct {
+		input string
+	}{
+		{input: "select columnA as something, columnB as something"},
+		{input: "select avg(columnA) as something, columnB as something"},
+		{input: "select avg(*) as something, columnB as something"},
+	}
+	for _, test := range testCases {
+		t.Run(test.input, func(tt *testing.T) {
+			_, _, err := pquerier.ParseQuery(test.input)
+			if err == nil {
+				tt.Fatalf("expected error but finished successfully")
+			}
+		})
+	}
+}

--- a/pkg/pquerier/sql_parser_test.go
+++ b/pkg/pquerier/sql_parser_test.go
@@ -83,7 +83,8 @@ func TestNegativeParseQuery(t *testing.T) {
 	}{
 		{input: "select columnA as something, columnB as something"},
 		{input: "select avg(columnA) as something, columnB as something"},
-		{input: "select avg(*) as something, columnB as something"},
+		{input: "select avg(*) as something"},
+		{input: "select avg(cpu), max(cpu) as cpu"},
 	}
 	for _, test := range testCases {
 		t.Run(test.input, func(tt *testing.T) {

--- a/pkg/pquerier/types.go
+++ b/pkg/pquerier/types.go
@@ -51,6 +51,17 @@ func (col *RequestedColumn) GetFunction() string {
 	return strings.TrimSuffix(col.Function, aggregate.CrossSeriesSuffix)
 }
 
+func (col *RequestedColumn) GetColumnName() string {
+	if col.Alias != "" {
+		return col.Alias
+	}
+	// If no aggregations are requested (raw down sampled data)
+	if col.Function == "" {
+		return col.Metric
+	}
+	return fmt.Sprintf("%v(%v)", col.Function, col.Metric)
+}
+
 type columnMeta struct {
 	metric                 string
 	alias                  string


### PR DESCRIPTION
Add SQL parsing error checks:
* cannot use same alias multiple times (tsdb-113)
* cannot use alias on wildcard
* cannot use metric name as alias (tsdb-112)