### PR TITLE
TSDB-85: Fix insertion into first partition in epoch.

### DIFF
--- a/pkg/appender/store.go
+++ b/pkg/appender/store.go
@@ -42,7 +42,10 @@ const maxLateArrivalInterval = 59 * 60 * 1000 // Max late arrival of 59min
 
 // Create a chunk store with two chunks (current, previous)
 func NewChunkStore(logger logger.Logger, labelNames []string, aggrsOnly bool) *chunkStore {
-	store := chunkStore{logger: logger}
+	store := chunkStore{
+		logger:  logger,
+		lastTid: -1,
+	}
 	if !aggrsOnly {
 		store.chunks[0] = &attrAppender{}
 		store.chunks[1] = &attrAppender{}

--- a/pkg/tsdb/v3iotsdb_integration_test.go
+++ b/pkg/tsdb/v3iotsdb_integration_test.go
@@ -103,6 +103,19 @@ func TestIngestData(t *testing.T) {
 					}}},
 			),
 		},
+		{desc: "Should ingest into first partition in epoch without corruption (TSDB-67)",
+			params: tsdbtest.NewTestParams(t,
+				tsdbtest.TestOption{
+					Key: tsdbtest.OptTimeSeries,
+					Value: tsdbtest.TimeSeries{tsdbtest.Metric{
+						Name:   "cool-cpu",
+						Labels: utils.LabelsFromStringList("os", "linux", "iguaz", "yesplease"),
+						Data: []tsdbtest.DataPoint{
+							{Time: 10, Value: 314.3},
+						},
+					}}},
+			),
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Before this fix, the data is corrupted.