### PR TITLE
IG-12276: Support pseudo-URL not only in tsdbctl.

### DIFF
--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -22,9 +22,6 @@ package tsdbctl
 
 import (
 	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/nuclio/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -170,26 +167,8 @@ func (rc *RootCommandeer) populateConfig(cfg *config.V3ioConfig) error {
 		cfg.LogLevel = config.DefaultLogLevel
 	}
 
-	// Prefix http:// in case that WebApiEndpoint is a pseudo-URL missing a scheme (for backward compatibility).
-	amendedWebApiEndpoint, err := buildUrl(cfg.WebApiEndpoint)
-	if err == nil {
-		cfg.WebApiEndpoint = amendedWebApiEndpoint
-	}
-
 	rc.v3iocfg = cfg
 	return nil
-}
-
-func buildUrl(webApiEndpoint string) (string, error) {
-	if !strings.HasPrefix(webApiEndpoint, "http://") && !strings.HasPrefix(webApiEndpoint, "https://") {
-		webApiEndpoint = "http://" + webApiEndpoint
-	}
-	endpointUrl, err := url.Parse(webApiEndpoint)
-	if err != nil {
-		return "", err
-	}
-	endpointUrl.Path = ""
-	return endpointUrl.String(), nil
 }
 
 func (rc *RootCommandeer) startAdapter() error {

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -22,6 +22,7 @@ package tsdbctl
 
 import (
 	"fmt"
+
 	"github.com/nuclio/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/pkg/tsdbctl/tsdbctl_test.go
+++ b/pkg/tsdbctl/tsdbctl_test.go
@@ -56,7 +56,7 @@ func (suite *testTsdbctlSuite) TestPopulateConfigWithTenant() {
 		Reporter: metricReporter,
 	}
 	expectedCfg := &config.V3ioConfig{
-		WebApiEndpoint: "http://localhost:80123",
+		WebApiEndpoint: "localhost:80123",
 		Container:      "123",
 		TablePath:      "/x/y/z",
 		Username:       "Vel@Odar",
@@ -79,12 +79,12 @@ func (suite *testTsdbctlSuite) TestContainerConfig() {
 	suite.Require().NoError(err)
 	defer os.Setenv("V3IO_ACCESS_KEY", oldAccessKey)
 
-	rc := RootCommandeer{v3ioUrl: "localhost:80123/123", container: "test", accessKey: "acce55-key"}
+	rc := RootCommandeer{v3ioUrl: "localhost:80123", container: "test", accessKey: "acce55-key"}
 	cfg := &config.V3ioConfig{Username: "Vel@Odar", Password: "p455w0rd", TablePath: "/x/y/z"}
 
 	err = rc.populateConfig(cfg)
 	expectedCfg := &config.V3ioConfig{
-		WebApiEndpoint: "http://localhost:80123",
+		WebApiEndpoint: "localhost:80123",
 		Container:      "test",
 		TablePath:      "/x/y/z",
 		Username:       "Vel@Odar",
@@ -114,7 +114,7 @@ func (suite *testTsdbctlSuite) TestConfigFromEnvVarsAndPassword() {
 
 	expectedCfg := *cfg
 	err = rc.populateConfig(cfg)
-	expectedCfg.WebApiEndpoint = "http://host-from-env:123"
+	expectedCfg.WebApiEndpoint = "host-from-env:123"
 	expectedCfg.Container = "test"
 	expectedCfg.TablePath = "/x/y/z"
 	expectedCfg.Username = "Vel@Odar"
@@ -142,7 +142,7 @@ func (suite *testTsdbctlSuite) TestConfigFromEnvVars() {
 
 	expectedCfg := *cfg
 	err = rc.populateConfig(cfg)
-	expectedCfg.WebApiEndpoint = "http://host-from-env:123"
+	expectedCfg.WebApiEndpoint = "host-from-env:123"
 	expectedCfg.AccessKey = "key-from-env"
 	expectedCfg.Container = "test"
 	expectedCfg.LogLevel = "info"


### PR DESCRIPTION
Testing requires setting `webApiEndpoint` to a pseudo-URL (e.g. `v3io-webapi`) rather than a true URL (e.g. `http://v3io-webapi`).