### PR TITLE
Revert "Use go mod vendor for tsdb-nuclio."

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,8 +80,10 @@ def build_nuclio(V3IO_TSDB_VERSION, internal_status="stable") {
                         container('jnlp') {
                             dir("${BUILD_FOLDER}/src/github.com/${git_project_upstream_user}/${git_project}") {
                                 sh """
-                                    GO111MODULE=on go get github.com/${git_project_user}/v3io-tsdb@${V3IO_TSDB_VERSION}
-                                    GO111MODULE=on go mod tidy
+                                    rm -rf functions/ingest/vendor/github.com/${git_project_upstream_user}/v3io-tsdb
+                                    git clone https://${GIT_TOKEN}@github.com/${git_project_user}/v3io-tsdb.git functions/ingest/vendor/github.com/${git_project_upstream_user}/v3io-tsdb
+                                    cd functions/ingest/vendor/github.com/${git_project_upstream_user}/v3io-tsdb
+                                    git checkout ${V3IO_TSDB_VERSION}
                                 """
                             }
                         }


### PR DESCRIPTION
Reverts v3io/v3io-tsdb#380

We'll need to do this another way, at least for 2.3.