### PR TITLE
IG-13262: Fix segfault when selecting a metric that does not exist.

### DIFF
--- a/pkg/pquerier/frames.go
+++ b/pkg/pquerier/frames.go
@@ -471,7 +471,14 @@ func (d *dataFrame) rawSeriesToColumns() error {
 
 	for i, rawSeries := range d.rawColumns {
 		if rawSeries == nil {
-			return errors.Errorf("failed to obtain column '%s'", d.columns[i].Name())
+			missingColumn := "(unknown column)"
+			for columnName, index := range d.columnByName {
+				if index == i {
+					missingColumn = fmt.Sprintf("'%s'", columnName)
+					break
+				}
+			}
+			return errors.Errorf("failed to obtain column %s", missingColumn)
 		}
 		if rawSeries.Iterator().Next() {
 			seriesHasMoreData[i] = true

--- a/pkg/pquerier/frames.go
+++ b/pkg/pquerier/frames.go
@@ -325,21 +325,30 @@ func (d *dataFrame) ColumnAt(i int) (Column, error) {
 		return nil, fmt.Errorf("index %d out of bounds [0:%d]", i, d.Len())
 	}
 	if d.shouldGenerateRawColumns() {
-		d.rawSeriesToColumns()
+		err := d.rawSeriesToColumns()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return d.columns[i], nil
 }
 
-func (d *dataFrame) Columns() []Column {
+func (d *dataFrame) Columns() ([]Column, error) {
 	if d.shouldGenerateRawColumns() {
-		d.rawSeriesToColumns()
+		err := d.rawSeriesToColumns()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return d.columns
+	return d.columns, nil
 }
 
 func (d *dataFrame) Column(name string) (Column, error) {
 	if d.shouldGenerateRawColumns() {
-		d.rawSeriesToColumns()
+		err := d.rawSeriesToColumns()
+		if err != nil {
+			return nil, err
+		}
 	}
 	i, ok := d.columnByName[name]
 	if !ok {
@@ -349,11 +358,14 @@ func (d *dataFrame) Column(name string) (Column, error) {
 	return d.columns[i], nil
 }
 
-func (d *dataFrame) Index() Column {
+func (d *dataFrame) Index() (Column, error) {
 	if d.shouldGenerateRawColumns() {
-		d.rawSeriesToColumns()
+		err := d.rawSeriesToColumns()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return d.index
+	return d.index, nil
 }
 
 func (d *dataFrame) TimeSeries(i int) (utils.Series, error) {
@@ -548,7 +560,10 @@ func (d *dataFrame) shouldGenerateRawColumns() bool { return d.isRawSeries && !d
 func (d *dataFrame) GetFrame() (frames.Frame, error) {
 	var framesColumns []frames.Column
 	if d.shouldGenerateRawColumns() {
-		d.rawSeriesToColumns()
+		err := d.rawSeriesToColumns()
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, col := range d.columns {
 		if !col.GetColumnSpec().isHidden {

--- a/pkg/pquerier/frames.go
+++ b/pkg/pquerier/frames.go
@@ -446,7 +446,7 @@ func (d *dataFrame) finishAllColumns() error {
 //	t1		  NaN		  v2
 //	t2		  v1		  v3
 //
-func (d *dataFrame) rawSeriesToColumns() {
+func (d *dataFrame) rawSeriesToColumns() error {
 	var timeData []time.Time
 
 	columns := make([]frames.ColumnBuilder, len(d.rawColumns))
@@ -458,6 +458,9 @@ func (d *dataFrame) rawSeriesToColumns() {
 	seriesHasMoreData := make([]bool, len(d.rawColumns))
 
 	for i, rawSeries := range d.rawColumns {
+		if rawSeries == nil {
+			return errors.Errorf("failed to obtain column '%s'", d.columns[i].Name())
+		}
 		if rawSeries.Iterator().Next() {
 			seriesHasMoreData[i] = true
 			t, _ := rawSeries.Iterator().At()
@@ -536,6 +539,8 @@ func (d *dataFrame) rawSeriesToColumns() {
 	}
 
 	d.isRawColumnsGenerated = true
+
+	return nil
 }
 
 func (d *dataFrame) shouldGenerateRawColumns() bool { return d.isRawSeries && !d.isRawColumnsGenerated }


### PR DESCRIPTION
Instead of a segfault, we now get the error propagated to the client that made the request, and the server remains functional.