### PR TITLE
IG-15233 fix hang in ingest

### DIFF
--- a/pkg/appender/ingest.go
+++ b/pkg/appender/ingest.go
@@ -86,7 +86,7 @@ func (mc *MetricsCache) metricFeed(index int) {
 								gotData = false
 							} else {
 								//check again if done in case this was the last update
-								if mc.updatesInFlight == 0 {
+								if len(mc.newUpdates) == 0 && gotData {
 									mc.updatesComplete <- 0
 								}
 							}

--- a/pkg/appender/ingest.go
+++ b/pkg/appender/ingest.go
@@ -90,10 +90,11 @@ func (mc *MetricsCache) metricFeed(index int) {
 								completeChan <- 0
 								gotCompletion = false
 								gotData = false
-								potentialCompletion = false
 							}
 						}
+						potentialCompletion = false
 					} else {
+						potentialCompletion = false
 						// Handle append requests (Add / AddFast)
 						gotData = true
 						metric := app.metric
@@ -122,7 +123,6 @@ func (mc *MetricsCache) metricFeed(index int) {
 						}
 						metric.Unlock()
 					}
-
 					// Poll if we have more updates (accelerate the outer select)
 					if i < mc.cfg.BatchSize {
 						select {


### PR DESCRIPTION
there are 2 issues that cause hang in ingest - 
1. when all requests were sent and answered and the only remaining item in asyncChannel is the waitForcomplition req it didn't enter again to the loop to see that everything is done and mark 'gotCompletion=true'
2. when all requests that were sent are answered and the remaining samples to ingest are out of the partition range, we push them again to metricsQueue but nothing makes it enter the loop again to read those metrics (we pop only on received updates)