### PR TITLE
don't remove in flight metric from cache (#538)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9
 	github.com/imdario/mergo v0.3.7
 	github.com/nuclio/logger v0.0.1
 	github.com/nuclio/nuclio-sdk-go v0.0.0-20190205170814-3b507fbd0324

--- a/pkg/appender/lru_cache.go
+++ b/pkg/appender/lru_cache.go
@@ -1,0 +1,92 @@
+package appender
+
+import (
+	clist "container/list"
+	"sync"
+)
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	maxEntries int
+	free       *clist.List
+	used       *clist.List
+	cache      map[uint64]*clist.Element
+	cond       *sync.Cond
+	mtx        sync.Mutex
+}
+
+type entry struct {
+	key   uint64
+	value *MetricState
+}
+
+func NewCache(max int) *Cache {
+	newCache := Cache{
+		maxEntries: max,
+		free:       clist.New(),
+		used:       clist.New(),
+		cache:      make(map[uint64]*clist.Element),
+	}
+	newCache.cond = sync.NewCond(&newCache.mtx)
+	return &newCache
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key uint64, value *MetricState) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if ee, ok := c.cache[key]; ok {
+		c.free.Remove(ee)
+		//check if element was already in list and if not push to front
+		c.used.MoveToFront(ee)
+		if c.used.Front() != ee {
+			c.used.PushFront(ee)
+		}
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.used.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.maxEntries != 0 && c.free.Len()+c.used.Len() > c.maxEntries {
+		c.removeOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key uint64) (value *MetricState, ok bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if ele, hit := c.cache[key]; hit {
+		c.free.Remove(ele)
+		//check if element was already in list and if not push to front
+		c.used.MoveToFront(ele)
+		if c.used.Front() != ele {
+			c.used.PushFront(ele)
+		}
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+func (c *Cache) removeOldest() {
+	for {
+		ele := c.free.Back()
+		if ele != nil {
+			c.free.Remove(ele)
+			kv := ele.Value.(*clist.Element).Value.(*entry)
+			delete(c.cache, kv.key)
+			return
+		}
+		c.cond.Wait()
+	}
+}
+
+func (c *Cache) ResetMetric(key uint64) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if ele, ok := c.cache[key]; ok {
+		c.used.Remove(ele)
+		c.free.PushFront(ele)
+		c.cond.Signal()
+	}
+}

--- a/pkg/appender/store.go
+++ b/pkg/appender/store.go
@@ -66,11 +66,12 @@ type chunkStore struct {
 	lastTid  int64
 	chunks   [2]*attrAppender
 
-	labelNames    []string
-	aggrList      *aggregate.AggregatesList
-	pending       pendingList
-	maxTime       int64
-	delRawSamples bool // TODO: for metrics w aggregates only
+	labelNames      []string
+	aggrList        *aggregate.AggregatesList
+	pending         pendingList
+	maxTime         int64
+	delRawSamples   bool // TODO: for metrics w aggregates only
+	numNotProcessed int64
 }
 
 func (cs *chunkStore) isAggr() bool {


### PR DESCRIPTION
* don't remove in flight metric from cache

* rename

* remove only unused metrics from cache

* add push to channel counter

* lint

* more lint

* remove unneeded check

* move to used list when touching an element

* typo

* use for loop instead of recursion

* remove null check

* add comment on log

* go mod tidy

* add a print of cache size

Co-authored-by: Dina Nimrodi <dinan@iguazio.com>