### PR TITLE
fix metric.lock race

### DIFF
--- a/pkg/appender/appender.go
+++ b/pkg/appender/appender.go
@@ -186,8 +186,8 @@ func (mc *MetricsCache) addMetric(hash uint64, name string, metric *MetricState)
 // Push append to async channel
 func (mc *MetricsCache) appendTV(metric *MetricState, t int64, v interface{}) {
 	metric.Lock()
-	defer metric.Unlock()
 	metric.store.numNotProcessed++
+	metric.Unlock()
 	mc.asyncAppendChan <- &asyncAppend{metric: metric, t: t, v: v}
 }
 


### PR DESCRIPTION
reverting part of the change done here https://github.com/v3io/v3io-tsdb/commit/dd94bdb40ebfca6c2f64232762b9530d8340f725

push to asyncAppendChan shouldn't be under lock